### PR TITLE
Basic upgrades implemented

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -87,18 +87,6 @@ export type WhenType = {
         [EventNameValue in EventName]?: (event: any, context?: TriggeredAbilityContext) => boolean;
     };
 
-// TODO UPGRADES
-// export interface IAttachmentConditionProps {
-//     limit?: number;
-//     myControl?: boolean;
-//     opponentControlOnly?: boolean;
-//     unique?: boolean;
-//     faction?: string | string[];
-//     trait?: string | string[];
-//     limitTrait?: traitLimit | traitLimit[];
-//     cardCondition?: (card: Card) => boolean;
-// }
-
 // ********************************************** INTERNAL TYPES **********************************************
 interface ITriggeredAbilityWhenProps extends ITriggeredAbilityBaseProps {
     when: WhenType;

--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -1,20 +1,22 @@
-import type { AbilityContext } from '../core/ability/AbilityContext.js';
-import PlayerAction from '../core/ability/PlayerAction.js';
-import { AbilityRestriction, EffectName, EventName, Location, PhaseName, PlayType, RelativePlayer } from '../core/Constants.js';
-import { payAdjustableResourceCost } from '../costs/CostLibrary.js';
-import { putIntoPlay } from '../gameSystems/GameSystemLibrary.js';
+import { AbilityContext } from '../core/ability/AbilityContext';
+import PlayerAction from '../core/ability/PlayerAction';
 import { Card } from '../core/card/Card';
-import type Player from '../core/Player.js';
-import { GameEvent } from '../core/event/GameEvent.js';
+import { AbilityRestriction, EventName, Location, PhaseName, PlayType } from '../core/Constants';
+import { GameEvent } from '../core/event/GameEvent';
+import { payAdjustableResourceCost } from '../costs/CostLibrary';
+import { attachUpgrade } from '../gameSystems/GameSystemLibrary';
 
 type ExecutionContext = AbilityContext & { onPlayCardSource: any };
 
-export class PlayUnitAction extends PlayerAction {
+export class PlayUpgradeAction extends PlayerAction {
+    // we pass in a targetResolver holding the attachUpgrade system so that the action will be blocked if there are no valid targets
     public constructor(card: Card) {
-        super(card, 'Play this unit', [payAdjustableResourceCost()]);
+        super(card, 'Play this upgrade', [payAdjustableResourceCost()], { gameSystem: attachUpgrade((context) => ({
+            upgrade: context.source
+        })) });
     }
 
-    public override executeHandler(context: ExecutionContext): void {
+    public override executeHandler(context: ExecutionContext) {
         const cardPlayedEvent = new GameEvent(EventName.OnCardPlayed, {
             player: context.player,
             card: context.source,
@@ -23,20 +25,12 @@ export class PlayUnitAction extends PlayerAction {
             originallyOnTopOfDeck:
                 context.player && context.player.drawDeck && context.player.drawDeck[0] === context.source,
             onPlayCardSource: context.onPlayCardSource,
-            playType: PlayType.PlayFromHand
+            playType: context.playType
         });
-
-        context.game.addMessage(
-            '{0} plays {1}',
-            context.player,
-            context.source,
-        );
-        const effect = context.source.getEffectValues(EffectName.EntersPlayForOpponent);
-        const player = effect.length > 0 ? RelativePlayer.Opponent : RelativePlayer.Self;
         context.game.openEventWindow([
-            putIntoPlay({
-                controller: player
-            }).generateEvent(context.source, context),
+            context.game.actions
+                .attachUpgrade({ upgrade: context.source, takeControl: context.source.controller !== context.player })
+                .generateEvent(context.target, context),
             cardPlayedEvent
         ]);
     }
@@ -62,21 +56,18 @@ export class PlayUnitAction extends PlayerAction {
         }
         if (
             context.player.hasRestriction(AbilityRestriction.PlayUnit, context) ||
-            context.player.hasRestriction(AbilityRestriction.PutIntoPlay, context) ||
-            context.source.hasRestriction(AbilityRestriction.EnterPlay, context)
+            context.player.hasRestriction(AbilityRestriction.PutIntoPlay, context)
         ) {
             return 'restriction';
         }
         return super.meetsRequirements(context);
     }
 
-    public override createContext(player: RelativePlayer = this.card.controller) {
-        const context = super.createContext(player);
-        context.costAspects = this.card.aspects;
-        return context;
+    public override displayMessage(context: AbilityContext) {
+        context.game.addMessage('{0} plays {1}, attaching it to {2}', context.player, context.source, context.target);
     }
 
-    public override isCardPlayed(): boolean {
+    public override isCardPlayed() {
         return true;
     }
 }

--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -11,7 +11,7 @@ type ExecutionContext = AbilityContext & { onPlayCardSource: any };
 export class PlayUpgradeAction extends PlayerAction {
     // we pass in a targetResolver holding the attachUpgrade system so that the action will be blocked if there are no valid targets
     public constructor(card: Card) {
-        super(card, 'Play this upgrade', [payAdjustableResourceCost()], { gameSystem: attachUpgrade((context) => ({
+        super(card, 'Play this upgrade', [payAdjustableResourceCost()], { immediateEffect: attachUpgrade((context) => ({
             upgrade: context.source
         })) });
     }

--- a/server/game/cardImplementations/01_SOR/Entrenched.ts
+++ b/server/game/cardImplementations/01_SOR/Entrenched.ts
@@ -1,0 +1,23 @@
+import AbilityHelper from '../../AbilityHelper';
+import { AbilityContext } from '../../core/ability/AbilityContext';
+import { Attack } from '../../core/attack/Attack';
+import { UpgradeCard } from '../../core/card/UpgradeCard';
+import { Trait } from '../../core/Constants';
+
+export default class Entrenched extends UpgradeCard {
+    protected override getImplementationId() {
+        return {
+            id: '3099663280',
+            internalName: 'entrenched',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addAttachedUnitEffectAbility({
+            title: 'Attached unit cannot attack bases',
+            ongoingEffect: AbilityHelper.ongoingEffects.cannotAttackBase(),
+        });
+    }
+}
+
+Entrenched.implemented = true;

--- a/server/game/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.ts
+++ b/server/game/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.ts
@@ -27,6 +27,7 @@ export default class SalaciousCrumbObnoxiousPet extends NonLeaderUnitCard {
                 AbilityHelper.costs.exhaustSelf(),
                 AbilityHelper.costs.returnSelfToHandFromPlay()
             ],
+            cannotTargetFirst: true,
             targetResolver: {
                 cardCondition: (card) => card.location === Location.GroundArena,
                 immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1 }),

--- a/server/game/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.ts
+++ b/server/game/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.ts
@@ -29,7 +29,7 @@ export default class SalaciousCrumbObnoxiousPet extends NonLeaderUnitCard {
             ],
             targetResolver: {
                 cardCondition: (card) => card.location === Location.GroundArena,
-                immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1 })
+                immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1 }),
             }
         });
     }

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -132,8 +132,6 @@ export enum WildcardCardType {
 }
 
 export type CardTypeFilter = CardType | WildcardCardType;
-export type Unit = CardType.NonLeaderUnit | CardType.LeaderUnit;
-export type Token = CardType.TokenUnit | CardType.TokenUpgrade;
 
 export enum EventName {
     OnBeginRound = 'onBeginRound',
@@ -174,6 +172,7 @@ export enum EventName {
     OnDamageRemoved = 'onDamageRemoved',
     OnAttackCompleted = 'onAttackCompleted',
     OnCardReturnedToHand = 'onCardReturnedToHand',
+    OnUpgradeAttached = 'onUpgradeAttached'
 }
 
 export enum AbilityType {
@@ -260,7 +259,7 @@ export enum AbilityRestriction {
     PutIntoPlay = 'putIntoPlay',
     /** Restricts a card from being played. Typically used for event cards, see {@link AbilityRestriction.PutIntoPlay} for other card types */
     Play = 'play',
-    /** Restricts a card or card type from being able to enter play. See {@link AbilityRestriction.Play} for event cards */
+    /** Restricts a card or card type from being able to enter play. Typically used for non-events. See {@link AbilityRestriction.Play} for event cards */
     EnterPlay = 'enterPlay',
     /** Restricts a game object from being targetable by abilities */
     Target = 'target',  // TODO: rename to AbilityTarget

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -2,17 +2,17 @@
 /* eslint @stylistic/js/lines-around-comment: off */
 
 export enum Location {
-    Hand = 'hand',
+    Base = 'base',
+    BeingPlayed = 'being played',
     Deck = 'deck',
     Discard = 'discard',
-    Base = 'base',
-    Leader = 'leader',
     GroundArena = 'ground arena',
-    SpaceArena = 'space arena',
-    Resource = 'resource',
-    RemovedFromGame = 'removed from game',
+    Hand = 'hand',
+    Leader = 'leader',
     OutsideTheGame = 'outside the game',
-    BeingPlayed = 'being played',
+    RemovedFromGame = 'removed from game',
+    Resource = 'resource',
+    SpaceArena = 'space arena',
 }
 
 export enum WildcardLocation {
@@ -33,53 +33,56 @@ export enum PlayType {
 }
 
 export enum StatType {
-    Power = 'power',
-    Hp = 'hp'
+    Hp = 'hp',
+    Power = 'power'
 }
 
 export enum EffectName {
     AbilityRestrictions = 'abilityRestrictions',
-    ChangeType = 'changeType',
-    SuppressEffects = 'suppressEffects',
-    ShowTopCard = 'showTopCard',
-    EntersPlayForOpponent = 'entersPlayForOpponent',
-    CostAdjuster = 'costAdjuster',
-    CanPlayFromOutOfPlay = 'canPlayFromOutOfPlay',
-    DoesNotReady = 'doesNotReady',
-    Blank = 'blank',
-    AddKeyword = 'addKeyword',
-    LoseKeyword = 'loseKeyword',
-    CanBeTriggeredByOpponent = 'canBeTriggeredByOpponent',
-    UnlessActionCost = 'unlessActionCost',
-    MustBeChosen = 'mustBeChosen',
-    TakeControl = 'takeControl',
     AdditionalAction = 'additionalActions',
     AdditionalActionAfterWindowCompleted = 'additionalActionsAfterWindowCompleted',
-    AdditionalTriggerCost = 'additionalTriggercost',
     AdditionalPlayCost = 'additionalPlaycost',
-    ModifyStats = 'modifyStats',
-    ModifyPower = 'modifyPower',
-    SetPower = 'setPower',
-    ModifyHp = 'modifyHp',
-    UpgradePowerModifier = 'upgradePowerModifier',
-    UpgradeHpModifier = 'upgradeHpModifier',
+    AdditionalTriggerCost = 'additionalTriggercost',
+    AddKeyword = 'addKeyword',
+    AddTrait = 'addTrait',
+    Blank = 'blank',
     CanAttackGroundArenaFromSpaceArena = 'canAttackGroundArenaFromSpaceArena',
     CanAttackSpaceArenaFromGroundArena = 'canAttackSpaceArenaFromGroundArena',
-    AddTrait = 'addTrait',
-    LoseTrait = 'loseTrait',
+    CanBeTriggeredByOpponent = 'canBeTriggeredByOpponent',
+    CanPlayFromOutOfPlay = 'canPlayFromOutOfPlay',
+    ChangeType = 'changeType',
+    CostAdjuster = 'costAdjuster',
     DelayedEffect = 'delayedEffect',
+    DoesNotReady = 'doesNotReady',
+    EntersPlayForOpponent = 'entersPlayForOpponent',
+    GainAbility = 'gainAbility',
     IncreaseLimitOnAbilities = 'increaseLimitOnAbilities',
+    LoseKeyword = 'loseKeyword',
+    LoseTrait = 'loseTrait',
+    ModifyHp = 'modifyHp',
+    ModifyPower = 'modifyPower',
+    ModifyStats = 'modifyStats',
+    MustBeChosen = 'mustBeChosen',
+    SetPower = 'setPower',
+    ShowTopCard = 'showTopCard',
+    SuppressEffects = 'suppressEffects',
+    TakeControl = 'takeControl',
+    UnlessActionCost = 'unlessActionCost',
+    UpgradeHpModifier = 'upgradeHpModifier',
+    UpgradePowerModifier = 'upgradePowerModifier',
+
+    // "cannot" effects
     CannotApplyLastingEffects = 'cannotApplyLastingEffects',
+    CannotAttackBase = 'cannotAttackBase',
     CannotBeAttacked = 'cannotBeAttacked',
-    GainAbility = 'gainAbility'
 }
 
 export enum Duration {
+    Custom = 'custom',
+    Persistent = 'persistent',
+    UntilEndOfAttack = 'untilEndOfAttack',
     UntilEndOfPhase = 'untilEndOfPhase',
     UntilEndOfRound = 'untilEndOfRound',
-    UntilEndOfAttack = 'untilEndOfAttack',
-    Persistent = 'persistent',
-    Custom = 'custom'
 }
 
 export enum Stage {
@@ -96,14 +99,14 @@ export enum RelativePlayer {
 }
 
 export enum TargetMode {
-    Select = 'select',
     Ability = 'ability',
-    Token = 'token',
     AutoSingle = 'autoSingle',
     Exactly = 'exactly',
     ExactlyVariable = 'exactlyVariable',
     MaxStat = 'maxStat',
+    Select = 'select',
     Single = 'single',
+    Token = 'token',
     Unlimited = 'unlimited',
     UpTo = 'upTo',
     UpToVariable = 'upToVariable'
@@ -115,80 +118,80 @@ export enum PhaseName {
 }
 
 export enum CardType {
-    NonLeaderUnit = 'nonLeaderUnit',
-    LeaderUnit = 'leaderUnit',
-    Leader = 'leader',
     Base = 'base',
     Event = 'event',
-    Upgrade = 'upgrade',
+    Leader = 'leader',
+    LeaderUnit = 'leaderUnit',
+    NonLeaderUnit = 'nonLeaderUnit',
     TokenUnit = 'tokenUnit',
     TokenUpgrade = 'tokenUpgrade',
+    Upgrade = 'upgrade',
 }
 
 export enum WildcardCardType {
-    Unit = 'unit',
+    Any = 'any',
     Token = 'token',
-    Any = 'any'
+    Unit = 'unit',
 }
 
 export type CardTypeFilter = CardType | WildcardCardType;
 
 export enum EventName {
+    OnAbilityResolved = 'onAbilityResolved',
+    OnAbilityResolverInitiated = 'onAbilityResolverInitiated',
+    OnAddTokenToCard = 'onAddTokenToCard',
+    OnAttackCompleted = 'onAttackCompleted',
+    OnAttackDeclared = 'onAttackDeclared',
     OnBeginRound = 'onBeginRound',
-    OnUnitEntersPlay = 'onUnitEntersPlay',
-    OnInitiateAbilityEffects = 'onInitiateAbilityEffects',
     OnCardAbilityInitiated = 'onCardAbilityInitiated',
     OnCardAbilityTriggered = 'onCardAbilityTriggered',
-    OnPhaseCreated = 'onPhaseCreated',
-    OnPhaseStarted = 'onPhaseStarted',
-    OnPhaseEnded = 'onPhaseEnded',
-    OnPhaseEndedCleanup = 'onPhaseEndedCleanup',
-    OnRoundEnded = 'onRoundEnded',
-    OnRoundEndedCleanup = 'onRoundEndedCleanup',
+    OnCardDefeated = 'onCardDefeated',
     OnCardExhausted = 'onCardExhausted',
+    OnCardMoved = 'onCardMoved',
+    OnCardPlayed = 'onCardPlayed',
     OnCardReadied = 'onCardReadied',
+    OnCardReturnedToHand = 'onCardReturnedToHand',
     OnCardsDiscarded = 'onCardsDiscarded',
     OnCardsDiscardedFromHand = 'onCardsDiscardedFromHand',
-    OnCardDefeated = 'onCardDefeated',
-    OnAddTokenToCard = 'onAddTokenToCard',
-    OnCardPlayed = 'onCardPlayed',
-    OnDeckShuffled = 'onDeckShuffled',
-    OnTakeInitiative = 'onTakeInitiative',
-    OnAbilityResolved = 'onAbilityResolved',
-    OnCardMoved = 'onCardMoved',
-    OnDeckSearch = 'onDeckSearch',
-    OnEffectApplied = 'onEffectApplied',
-    OnStatusTokenDiscarded = 'onStatusTokenDiscarded',
-    OnStatusTokenMoved = 'onStatusTokenMoved',
-    OnStatusTokenGained = 'onStatusTokenGained',
     OnCardsDrawn = 'onCardsDrawn',
-    OnLookAtCards = 'onLookAtCards',
-    OnPassActionPhasePriority = 'onPassActionPhasePriority',
-    Unnamed = 'unnamedEvent',
-    OnAbilityResolverInitiated = 'onAbilityResolverInitiated',
-    OnSpendResources = 'onSpendResources',
-    OnAttackDeclared = 'onAttackDeclared',
     OnDamageDealt = 'onDamageDealt',
     OnDamageRemoved = 'onDamageRemoved',
-    OnAttackCompleted = 'onAttackCompleted',
-    OnCardReturnedToHand = 'onCardReturnedToHand',
-    OnUpgradeAttached = 'onUpgradeAttached'
+    OnDeckSearch = 'onDeckSearch',
+    OnDeckShuffled = 'onDeckShuffled',
+    OnEffectApplied = 'onEffectApplied',
+    OnInitiateAbilityEffects = 'onInitiateAbilityEffects',
+    OnLookAtCards = 'onLookAtCards',
+    OnPassActionPhasePriority = 'onPassActionPhasePriority',
+    OnPhaseCreated = 'onPhaseCreated',
+    OnPhaseEnded = 'onPhaseEnded',
+    OnPhaseEndedCleanup = 'onPhaseEndedCleanup',
+    OnPhaseStarted = 'onPhaseStarted',
+    OnRoundEnded = 'onRoundEnded',
+    OnRoundEndedCleanup = 'onRoundEndedCleanup',
+    OnSpendResources = 'onSpendResources',
+    OnStatusTokenDiscarded = 'onStatusTokenDiscarded',
+    OnStatusTokenGained = 'onStatusTokenGained',
+    OnStatusTokenMoved = 'onStatusTokenMoved',
+    OnTakeInitiative = 'onTakeInitiative',
+    OnUnitEntersPlay = 'onUnitEntersPlay',
+    OnUpgradeAttached = 'onUpgradeAttached',
+    Unnamed = 'unnamedEvent',
 }
 
 export enum AbilityType {
     Action = 'action',
-    Triggered = 'triggered',
     Constant = 'constant',
-    Event = 'event'
+    Event = 'event',
+    Triggered = 'triggered',
 }
 
 export enum Aspect {
-    Heroism = 'heroism',
-    Villainy = 'villainy',
     Aggression = 'aggression',
     Command = 'command',
     Cunning = 'cunning',
-    Vigilance = 'vigilance'
+    Heroism = 'heroism',
+    Vigilance = 'vigilance',
+    Villainy = 'villainy',
 }
 
 export enum Keyword {
@@ -197,54 +200,54 @@ export enum Keyword {
 }
 
 export enum Trait {
-    Force = 'force',
-    Rebel = 'rebel',
-    Imperial = 'imperial',
-    Sith = 'sith',
-    Trooper = 'trooper',
-    Official = 'official',
-    Vehicle = 'vehicle',
+    Armor = 'armor',
+    Bounty = 'bounty',
+    BountyHunter = 'bounty hunter',
+    CapitalShip = 'capital ship',
+    Clone = 'clone',
+    Condition = 'condition',
+    Creature = 'creature',
+    Disaster = 'disaster',
+    Droid = 'droid',
     Fighter = 'fighter',
-    Innate = 'innate',
+    FirstOrder = 'first order',
+    Force = 'force',
+    Fringe = 'fringe',
     Gambit = 'gambit',
-    Underworld = 'underworld',
-    Wookiee = 'wookiee',
+    Hutt = 'hutt',
+    Imperial = 'imperial',
+    Innate = 'innate',
+    Inquisitor = 'inquisitor',
+    Item = 'item',
+    Jawa = 'jawa',
     Jedi = 'jedi',
+    Law = 'law',
+    Learned = 'learned',
+    Lightsaber = 'lightsaber',
+    Mandalorian = 'mandalorian',
+    Modification = 'modification',
+    NewRepublic = 'new republic',
+    Official = 'official',
+    Plan = 'plan',
+    Rebel = 'rebel',
+    Republic = 'republic',
+    Resistance = 'resistance',
+    Separatist = 'separatist',
+    Sith = 'sith',
+    Spectre = 'spectre',
+    Speeder = 'speeder',
     Supply = 'supply',
     Tactic = 'tactic',
-    Item = 'item',
-    Weapon = 'weapon',
-    Lightsaber = 'lightsaber',
-    Separatist = 'separatist',
-    Learned = 'learned',
-    Armor = 'armor',
-    FirstOrder = 'first order',
-    Mandalorian = 'mandalorian',
-    BountyHunter = 'bounty hunter',
-    Droid = 'droid',
-    Spectre = 'spectre',
-    Walker = 'walker',
-    Law = 'law',
-    Creature = 'creature',
-    Fringe = 'fringe',
-    Plan = 'plan',
-    Twilek = 'twi\'lek',
-    Trick = 'trick',
-    Clone = 'clone',
-    Bounty = 'bounty',
-    Condition = 'condition',
-    Republic = 'republic',
-    Speeder = 'speeder',
-    Transport = 'transport',
-    Disaster = 'disaster',
-    CapitalShip = 'capital ship',
-    Hutt = 'hutt',
     Tank = 'tank',
-    Inquisitor = 'inquisitor',
-    Jawa = 'jawa',
-    NewRepublic = 'new republic',
-    Modification = 'modification',
-    Resistance = 'resistance'
+    Transport = 'transport',
+    Trick = 'trick',
+    Trooper = 'trooper',
+    Twilek = 'twi\'lek',
+    Underworld = 'underworld',
+    Vehicle = 'vehicle',
+    Walker = 'walker',
+    Weapon = 'weapon',
+    Wookiee = 'wookiee',
 }
 
 // TODO: these could stand to be reorganized and cleaned up a bit
@@ -253,6 +256,7 @@ export enum AbilityRestriction {
     Attack = 'attack',
     /** Restricts a card from being declared as an attack target */
     BeAttacked = 'beAttacked',
+
     /** Restricts a player's ability to play units */
     PlayUnit = 'playUnit',
     /** Restricts a player's ability to put a certain card or type of card into play */
@@ -261,10 +265,12 @@ export enum AbilityRestriction {
     Play = 'play',
     /** Restricts a card or card type from being able to enter play. Typically used for non-events. See {@link AbilityRestriction.Play} for event cards */
     EnterPlay = 'enterPlay',
+
     /** Restricts a game object from being targetable by abilities */
     Target = 'target',  // TODO: rename to AbilityTarget
-    TriggerAbilities = 'triggerAbilities',
+
+    BeHealed = 'beHealed',
     InitiateKeywords = 'initiateKeywords',
     ReceiveDamage = 'receiveDamage',
-    BeHealed = 'beHealed',
+    TriggerAbilities = 'triggerAbilities',
 }

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -272,7 +272,7 @@ class Game extends EventEmitter {
     }
 
     /**
-     * Returns if a card is in play (characters, attachments, provinces, holdings) that has the passed trait
+     * Returns if a card is in play (units, upgrades, base, leader) that has the passed trait
      * @param {string} trait
      * @returns {boolean} true/false if the trait is in pay
      */
@@ -1067,7 +1067,6 @@ class Game extends EventEmitter {
         // check for a game state change (recalculating attack stats if necessary)
         if (
             (!this.currentAttack && this.ongoingEffectEngine.resolveEffects(hasChanged)) ||
-            (this.currentAttack && this.currentAttack.calculateSkill(hasChanged)) ||
             hasChanged
         ) {
             // this.checkWinCondition();

--- a/server/game/core/GameObject.ts
+++ b/server/game/core/GameObject.ts
@@ -44,7 +44,7 @@ export abstract class GameObject {
         return filteredEffects.reduce((total, effect) => total + effect, 0);
     }
 
-    public anyEffect(type: EffectName) {
+    public hasEffect(type: EffectName) {
         return this.getEffectValues(type).length > 0;
     }
 

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -1103,8 +1103,10 @@ class Player extends GameObject {
 
             // In normal play, all upgrades should already have been removed, but in manual play we may need to remove them.
             // This won't trigger any leaves play effects
-            for (const upgrade of card.upgrades) {
-                upgrade.owner.moveCard(upgrade, Location.Discard);
+            if (card.isUnit()) {
+                for (const upgrade of card.upgrades) {
+                    upgrade.owner.moveCard(upgrade, Location.Discard);
+                }
             }
 
             card.controller = this;

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -1281,7 +1281,7 @@ class Player extends GameObject {
     }
 
     // eventsCannotBeCancelled() {
-    //     return this.anyEffect(EffectName.EventsCannotBeCancelled);
+    //     return this.hasEffect(EffectName.EventsCannotBeCancelled);
     // }
 
     // // TODO STATE SAVE: what stats are we interested in?

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -222,7 +222,7 @@ class Player extends GameObject {
     }
 
     /**
-     * Returns an Array of BaseCard which match (or whose attachments match) passed predicate in the passed list
+     * Returns an Array of BaseCard which match (or whose upgrades match) passed predicate in the passed list
      * @param cardList _(Array)
      * @param {Function} predicate - BaseCard => Boolean
      */
@@ -238,8 +238,8 @@ class Player extends GameObject {
                 cardsToReturn.push(card);
             }
 
-            if (card.attachments) {
-                cardsToReturn = cardsToReturn.concat(card.attachments.filter(predicate));
+            if (card.upgrades) {
+                cardsToReturn = cardsToReturn.concat(card.upgrades.filter(predicate));
             }
 
             return cardsToReturn;
@@ -249,7 +249,7 @@ class Player extends GameObject {
     }
 
     /**
-     * Returns if a card is in play (characters, attachments, provinces, holdings) that has the passed trait
+     * Returns if a card is in play (unots, upgrades, provinces, holdings) that has the passed trait
      * @param {string} trait
      * @returns {boolean} true/false if the trait is in pay
      */
@@ -265,7 +265,7 @@ class Player extends GameObject {
     }
 
     /**
-     * Returns true if any characters or attachments controlled by this playe match the passed predicate
+     * Returns true if any unots or upgrades controlled by this playe match the passed predicate
      * @param {Function} predicate - DrawCard => Boolean
      */
     anyCardsInPlay(predicate) {
@@ -275,15 +275,7 @@ class Player extends GameObject {
     }
 
     /**
-     * Returns an array of all conflict cards matching the predicate owned by this player
-     * @param {Function} predicate - DrawCard => Boolean
-     */
-    getAllConflictCards(predicate = () => true) {
-        return this.game.allCards.filter((card) => card.owner === this && card.isConflict && predicate(card));
-    }
-
-    /**
-     * Returns an Array of all characters and attachments matching the predicate controlled by this player
+     * Returns an Array of all unots and upgrades matching the predicate controlled by this player
      * @param {Function} predicate  - DrawCard => Boolean
      */
     filterCardsInPlay(predicate) {
@@ -474,7 +466,7 @@ class Player extends GameObject {
     // }
 
     /**
-     * Returns the total number of characters and attachments controlled by this player which match the passed predicate
+     * Returns the total number of units and upgrades controlled by this player which match the passed predicate
      * @param {Function} predicate - DrawCard => Int
      */
     getNumberOfCardsInPlay(predicate) {

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -113,7 +113,7 @@ class Player extends GameObject {
         this.clock.reset();
     }
 
-    // TODO UPGRADES: this should retrieve upgrades, but we need to confirm once they're implemented
+    // TODO THIS PR: this should retrieve upgrades, but we need to confirm once they're implemented
     /**
      * Get all cards in designated play arena(s) owned by this player
      * @param { import('./Constants').Arena | null } arena Arena to select units from. If null, selects cards from both arenas.
@@ -996,15 +996,14 @@ class Player extends GameObject {
         return legalLocationsForType && EnumHelpers.cardLocationMatches(location, legalLocationsForType);
     }
 
-    // TODO UPGRADES
-    // /**
-    //  * This is only used when an upgrade is dragged into play.  Usually,
-    //  * upgrades are played by playCard()
-    //  * @deprecated
-    //  */
-    // promptForUpgrade(card, playingType) {
-    //     this.game.queueStep(new AttachmentPrompt(this.game, this, card, playingType));
-    // }
+    /**
+     * This is only used when an upgrade is dragged into play.  Usually,
+     * upgrades are played by playCard()
+     * @deprecated
+     */
+    promptForUpgrade(card, playingType) {
+        this.game.queueStep(new UpgradePrompt(this.game, this, card, playingType));
+    }
 
     // get skillModifier() {
     //     return this.getEffectValues(EffectName.ChangePlayerSkillModifier).reduce((total, value) => total + value, 0);

--- a/server/game/core/ability/CardAbility.js
+++ b/server/game/core/ability/CardAbility.js
@@ -91,19 +91,19 @@ class CardAbility extends CardAbilityStep {
     /** @override */
     getCosts(context, playCosts = true, triggerCosts = true) {
         let costs = super.getCosts(context, playCosts);
-        if (!context.subResolution && triggerCosts && context.player.anyEffect(EffectName.AdditionalTriggerCost)) {
+        if (!context.subResolution && triggerCosts && context.player.hasEffect(EffectName.AdditionalTriggerCost)) {
             const additionalTriggerCosts = context.player
                 .getEffectValues(EffectName.AdditionalTriggerCost)
                 .map((effect) => effect(context));
             costs = costs.concat(...additionalTriggerCosts);
         }
-        if (!context.subResolution && triggerCosts && context.source.anyEffect(EffectName.AdditionalTriggerCost)) {
+        if (!context.subResolution && triggerCosts && context.source.hasEffect(EffectName.AdditionalTriggerCost)) {
             const additionalTriggerCosts = context.source
                 .getEffectValues(EffectName.AdditionalTriggerCost)
                 .map((effect) => effect(context));
             costs = costs.concat(...additionalTriggerCosts);
         }
-        if (!context.subResolution && playCosts && context.player.anyEffect(EffectName.AdditionalPlayCost)) {
+        if (!context.subResolution && playCosts && context.player.hasEffect(EffectName.AdditionalPlayCost)) {
             const additionalPlayCosts = context.player
                 .getEffectValues(EffectName.AdditionalPlayCost)
                 .map((effect) => effect(context));

--- a/server/game/core/ability/CardActionAbility.ts
+++ b/server/game/core/ability/CardActionAbility.ts
@@ -57,7 +57,7 @@ export class CardActionAbility extends CardAbility {
         }
 
         const canOpponentTrigger =
-            this.card.anyEffect(EffectName.CanBeTriggeredByOpponent) &&
+            this.card.hasEffect(EffectName.CanBeTriggeredByOpponent) &&
             this.abilityType !== AbilityType.Triggered;
         const canPlayerTrigger = this.anyPlayer || context.player === this.card.controller || canOpponentTrigger;
         if (!ignoredRequirements.includes('player') && !this.card.isEvent() && !canPlayerTrigger) {

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -86,7 +86,7 @@ export default class TriggeredAbility extends CardAbility {
 
     public override meetsRequirements(context, ignoredRequirements = []) {
         const canOpponentTrigger =
-            this.card.anyEffect(EffectName.CanBeTriggeredByOpponent) &&
+            this.card.hasEffect(EffectName.CanBeTriggeredByOpponent) &&
             this.abilityType !== AbilityType.Triggered;
         const canPlayerTrigger = this.anyPlayer || context.player === this.card.controller || canOpponentTrigger;
 

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -80,7 +80,7 @@ export class Card extends OngoingEffectSource {
         public readonly owner: Player,
         private readonly cardData: any
     ) {
-        super(owner.game);
+        super(owner.game, cardData.title);
 
         this.validateCardData(cardData);
         this.validateImplementationId(cardData);

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -556,7 +556,7 @@ export class Card extends OngoingEffectSource {
 
     /**
      * Deals with the engine effects of leaving play, making sure all statuses are removed. Anything which changes
-     * the state of the card should be here. This is also called in some strange corner cases e.g. for attachments
+     * the state of the card should be here. This is also called in some strange corner cases e.g. for upgrades
      * which aren't actually in play themselves when their parent (which is in play) leaves play.
      */
     public leavesPlay() {

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -346,7 +346,7 @@ export class Card extends OngoingEffectSource {
 
     // *************************************** EFFECT HELPERS ***************************************
     public isBlank(): boolean {
-        return this.anyEffect(EffectName.Blank);
+        return this.hasEffect(EffectName.Blank);
     }
 
     public canTriggerAbilities(context: AbilityContext, ignoredRequirements = []): boolean {
@@ -640,7 +640,7 @@ export class Card extends OngoingEffectSource {
     //     if (
     //         isActivePlayer
     //             ? this.isFacedown() && this.hideWhenFacedown()
-    //             : this.isFacedown() || hideWhenFaceup || this.anyEffect(EffectName.HideWhenFaceUp)
+    //             : this.isFacedown() || hideWhenFaceup || this.hasEffect(EffectName.HideWhenFaceUp)
     //     ) {
     //         let state = {
     //             controller: this.controller.getShortSummary(),

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -558,16 +558,8 @@ export class Card extends OngoingEffectSource {
      * Deals with the engine effects of leaving play, making sure all statuses are removed. Anything which changes
      * the state of the card should be here. This is also called in some strange corner cases e.g. for attachments
      * which aren't actually in play themselves when their parent (which is in play) leaves play.
-     *
-     * Note that a card becoming a resource is _not_ leaving play.
      */
     public leavesPlay() {
-        // // If this is an attachment and is attached to another card, we need to remove all links between them
-        // if (this.parent && this.parent.attachments) {
-        //     this.parent.removeAttachment(this);
-        //     this.parent = null;
-        // }
-
         // TODO: reuse this for capture logic
         // // Remove any cards underneath from the game
         // const cardsUnderneath = this.controller.getCardPile(this.uuid).map((a) => a);
@@ -622,7 +614,7 @@ export class Card extends OngoingEffectSource {
     //     clone.exhausted = this.exhausted;
     //     // clone.statusTokens = [...this.statusTokens];
     //     clone.location = this.location;
-    //     clone.parent = this.parent;
+    //     clone.parentCard = this.parentCard;
     //     clone.aspects = [...this.aspects];
     //     // clone.fate = this.fate;
     //     // clone.inConflict = this.inConflict;

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -39,18 +39,17 @@ export class Card extends OngoingEffectSource {
     public controller: Player;
 
     protected override readonly id: string;
-    protected abilityInitializers: IAbilityInitializer[] = [];
     protected readonly printedKeywords: Set<Keyword>;   // TODO KEYWORDS: enum of keywords
     protected readonly printedTraits: Set<Trait>;
     protected readonly printedType: CardType;
 
+    protected abilityInitializers: IAbilityInitializer[] = [];
     protected _actionAbilities: CardActionAbility[];
     protected _controller: Player;
     protected defaultController: Player;
     protected _facedown = true;
     protected hiddenForController = true;      // TODO: is this correct handling of hidden / visible card state? not sure how this integrates with the client
     protected hiddenForOpponent = true;
-    protected _upgrades: Card[] = [];
 
     private _location: Location;
 
@@ -75,11 +74,6 @@ export class Card extends OngoingEffectSource {
     public get type(): CardType {
         return this.printedType;
     }
-
-    public get upgrades(): Card[] {
-        return this._upgrades;
-    }
-
 
     // *********************************************** CONSTRUCTOR ***********************************************
     public constructor(

--- a/server/game/core/card/CardTypes.ts
+++ b/server/game/core/card/CardTypes.ts
@@ -25,6 +25,13 @@ export type CardWithPrintedHp =
     UpgradeCard |
     TokenUpgradeCard;
 
+export type CardWithPrintedPower =
+    NonLeaderUnitCard |
+    LeaderUnitCard |
+    TokenNonLeaderUnitCard |
+    UpgradeCard |
+    TokenUpgradeCard;
+
 export type CardWithTriggeredAbilities = InPlayCard;
 export type CardWithConstantAbilities = InPlayCard;
 

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -4,23 +4,48 @@ import { WithCost } from './propertyMixins/Cost';
 import { InPlayCard } from './baseClasses/InPlayCard';
 import { WithPrintedPower } from './propertyMixins/PrintedPower';
 import Contract from '../utils/Contract';
-import { CardType, Location } from '../Constants';
+import { CardType, Location, RelativePlayer } from '../Constants';
+import { UnitCard } from './CardTypes';
+import { PlayUpgradeAction } from '../../actions/PlayUpgradeAction';
+import { IConstantAbilityProps } from '../../Interfaces';
+import { Card } from './Card';
 
 const UpgradeCardParent = WithPrintedPower(WithPrintedHp(WithCost(InPlayCard)));
 
 export class UpgradeCard extends UpgradeCardParent {
-    public constructor(
-        owner: Player,
-        cardData: any
-    ) {
+    protected _parentCard?: UnitCard = null;
+
+    public constructor(owner: Player, cardData: any) {
         super(owner, cardData);
         Contract.assertTrue(this.printedType === CardType.Upgrade);
 
-        // TODO UPGRADES: add play event action to this._actions (see Unit.ts for reference)
+        this.defaultActions.push(new PlayUpgradeAction(this));
     }
 
     public override isUpgrade() {
         return true;
+    }
+
+    // TODO CAPTURE: we may need to use the "parent" concept for captured cards as well
+    /** The card that this card is underneath */
+    public get parentCard(): UnitCard {
+        this.assertPropertyEnabled(this._parentCard, 'parentCard');
+        return this._parentCard;
+    }
+
+    /**
+     * Helper that adds an "Attached unit gains:" ability. By default the effect will
+     * target the parent unit, but you can provide a match function to narrow down whether the
+     * effect is applied (for cases where the effect has conditions).
+     */
+    protected addAttachedUnitGains(properties: Pick<IConstantAbilityProps<this>, 'title' | 'condition' | 'match' | 'ongoingEffect'>) {
+        this.addConstantAbility({
+            title: properties.title,
+            condition: properties.condition || (() => true),
+            match: (card, context) => card === this.parentCard && (!properties.match || properties.match(card, context)),
+            targetController: RelativePlayer.Any,   // this means that the effect continues to work even if the other player gains control of the upgrade
+            ongoingEffect: properties.ongoingEffect
+        });
     }
 
     protected override initializeForCurrentLocation(prevLocation: Location): void {
@@ -37,121 +62,15 @@ export class UpgradeCard extends UpgradeCardParent {
         }
     }
 
-    // TODO UPGRADES: this was in the L5R code as "updateEffectContext()", not sure yet what the need is
-    protected updateConstantAbilityContexts() {
-        for (const constantAbility of this._constantAbilities) {
-            if (constantAbility.registeredEffects) {
-                for (const effect of constantAbility.registeredEffects) {
-                    effect.refreshContext();
-                }
-            }
+    /**
+     * Checks whether the passed card meets any attachment restrictions for this card. Upgrade
+     * implementations must override this if they have specific attachment conditions.
+     */
+    public canAttach(parentCard: Card, controller: Player = this.controller): boolean {
+        if (!parentCard.isUnit()) {
+            return false;
         }
+
+        return true;
     }
-
-    // TODO UPGRADES: all of the below came from L5R attachments
-    // /**
-    //  * Applies an effect with the specified properties while the current card is
-    //  * attached to another card. By default the effect will target the parent
-    //  * card, but you can provide a match function to narrow down whether the
-    //  * effect is applied (for cases where the effect only applies to specific
-    //  * characters).
-    //  */
-    // whileAttached(properties: Pick<PersistentEffectProps<this>, 'condition' | 'match' | 'effect'>) {
-    //     this.persistentEffect({
-    //         condition: properties.condition || (() => true),
-    //         match: (card, context) => card === this.parent && (!properties.match || properties.match(card, context)),
-    //         targetController: RelativePlayer.Any,
-    //         effect: properties.effect
-    //     });
-    // }
-
-    // /**
-    //  * Checks whether the passed card meets the attachment restrictions (e.g.
-    //  * Opponent cards only, specific factions, etc) for this card.
-    //  */
-    // canAttach(parent?: BaseCard, properties = { ignoreType: false, controller: this.controller }) {
-    //     if (!(parent instanceof BaseCard)) {
-    //         return false;
-    //     }
-
-    //     if (
-    //         parent.getType() !== CardType.Character ||
-    //         (!properties.ignoreType && this.getType() !== CardType.Attachment)
-    //     ) {
-    //         return false;
-    //     }
-
-    //     const attachmentController = properties.controller ?? this.controller;
-    //     for (const effect of this.getEffects() as OngoingCardEffect[]) {
-    //         switch (effect.type) {
-    //             case EffectName.AttachmentMyControlOnly: {
-    //                 if (attachmentController !== parent.controller) {
-    //                     return false;
-    //                 }
-    //                 break;
-    //             }
-    //             case EffectName.AttachmentOpponentControlOnly: {
-    //                 if (attachmentController === parent.controller) {
-    //                     return false;
-    //                 }
-    //                 break;
-    //             }
-    //             case EffectName.AttachmentUniqueRestriction: {
-    //                 if (!parent.isUnique()) {
-    //                     return false;
-    //                 }
-    //                 break;
-    //             }
-    //             case EffectName.AttachmentFactionRestriction: {
-    //                 const factions = effect.getValue<Faction[]>(this as any);
-    //                 if (!factions.some((faction) => parent.isFaction(faction))) {
-    //                     return false;
-    //                 }
-    //                 break;
-    //             }
-    //             case EffectName.AttachmentTraitRestriction: {
-    //                 const traits = effect.getValue<string[]>(this as any);
-    //                 if (!traits.some((trait) => parent.hasSomeTrait(trait))) {
-    //                     return false;
-    //                 }
-    //                 break;
-    //             }
-    //             case EffectName.AttachmentCardCondition: {
-    //                 const cardCondition = effect.getValue<(card: BaseCard) => boolean>(this as any);
-    //                 if (!cardCondition(parent)) {
-    //                     return false;
-    //                 }
-    //                 break;
-    //             }
-    //         }
-    //     }
-    //     return true;
-    // }
-
-
-    // TODO UPGRADES: these status token modifier methods could be reused for upgrades maybe? unclear how relevant they are
-    // getStatusTokenSkill() {
-    //     const modifiers = this.getStatusTokenModifiers();
-    //     const skill = modifiers.reduce((total, modifier) => total + modifier.amount, 0);
-    //     if (isNaN(skill)) {
-    //         return 0;
-    //     }
-    //     return skill;
-    // }
-
-    // getStatusTokenModifiers() {
-    //     let modifiers = [];
-    //     let modifierEffects = this.getEffects().filter((effect) => effect.type === EffectName.ModifyBothSkills);
-
-    //     // skill modifiers
-    //     modifierEffects.forEach((modifierEffect) => {
-    //         const value = modifierEffect.getValue(this);
-    //         modifiers.push(StatModifier.fromEffect(value, modifierEffect));
-    //     });
-    //     modifiers = modifiers.filter((modifier) => modifier.type === 'token');
-
-    //     // adjust honor status effects
-    //     this.adjustHonorStatusModifiers(modifiers);
-    //     return modifiers;
-    // }
 }

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -4,7 +4,7 @@ import { WithCost } from './propertyMixins/Cost';
 import { InPlayCard } from './baseClasses/InPlayCard';
 import { WithPrintedPower } from './propertyMixins/PrintedPower';
 import Contract from '../utils/Contract';
-import { CardType, Location, RelativePlayer } from '../Constants';
+import { AbilityType, CardType, Location, RelativePlayer } from '../Constants';
 import { UnitCard } from './CardTypes';
 import { PlayUpgradeAction } from '../../actions/PlayUpgradeAction';
 import { IConstantAbilityProps } from '../../Interfaces';

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -34,11 +34,25 @@ export class UpgradeCard extends UpgradeCardParent {
     }
 
     /**
+     * Helper that adds an effect that applies to the attached unit. Yyou can provide a match function
+     * to narrow down whether the effect is applied (for cases where the effect has conditions).
+     */
+    protected addAttachedUnitEffectAbility(properties: Pick<IConstantAbilityProps<this>, 'title' | 'condition' | 'match' | 'ongoingEffect'>) {
+        this.addConstantAbility({
+            title: properties.title,
+            condition: properties.condition || (() => true),
+            match: (card, context) => card === this.parentCard && (!properties.match || properties.match(card, context)),
+            targetController: RelativePlayer.Any,   // this means that the effect continues to work even if the other player gains control of the upgrade
+            ongoingEffect: properties.ongoingEffect
+        });
+    }
+
+    /**
      * Helper that adds an "Attached unit gains:" ability. By default the effect will
      * target the parent unit, but you can provide a match function to narrow down whether the
      * effect is applied (for cases where the effect has conditions).
      */
-    protected addAttachedUnitGains(properties: Pick<IConstantAbilityProps<this>, 'title' | 'condition' | 'match' | 'ongoingEffect'>) {
+    protected addAttachedUnitGainsTriggeredAbilityAbility(properties: Pick<IConstantAbilityProps<this>, 'title' | 'condition' | 'match' | 'ongoingEffect'>) {
         this.addConstantAbility({
             title: properties.title,
             condition: properties.condition || (() => true),

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -152,6 +152,17 @@ export class InPlayCard extends PlayableOrDeployableCard {
     }
 
     // ******************************************** ABILITY STATE MANAGEMENT ********************************************
+    /** Update the context of each constant ability. Used when the card's controller has changed. */
+    public updateConstantAbilityContexts() {
+        for (const constantAbility of this._constantAbilities) {
+            if (constantAbility.registeredEffects) {
+                for (const effect of constantAbility.registeredEffects) {
+                    effect.refreshContext();
+                }
+            }
+        }
+    }
+
     protected override initializeForCurrentLocation(prevLocation: Location) {
         super.initializeForCurrentLocation(prevLocation);
 
@@ -197,9 +208,6 @@ export class InPlayCard extends PlayableOrDeployableCard {
         if (!EnumHelpers.isArena(from) && !EnumHelpers.isArena(to)) {
             this.removeLastingEffects();
         }
-
-        // TODO UPGRADES: is this needed for upgrades?
-        // this.updateStatusTokenEffects();
 
         // check to register / unregister any effects that we are the source of
         for (const constantAbility of this._constantAbilities) {

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -20,8 +20,6 @@ export type InPlayCardConstructor = new (...args: any[]) => InPlayCard;
  * 2. The ability to be defeated as an overridable method
  */
 export class InPlayCard extends PlayableOrDeployableCard {
-    public readonly defaultArena: Arena;
-
     protected _triggeredAbilities: TriggeredAbility[] = [];
     protected _constantAbilities: IConstantAbility[] = [];
 
@@ -35,18 +33,6 @@ export class InPlayCard extends PlayableOrDeployableCard {
     // ********************************************** CONSTRUCTOR **********************************************
     public constructor(owner: Player, cardData: any) {
         super(owner, cardData);
-
-        Contract.assertNotNullLike(cardData.arena);
-        switch (cardData.arena) {
-            case 'space':
-                this.defaultArena = Location.SpaceArena;
-                break;
-            case 'ground':
-                this.defaultArena = Location.GroundArena;
-                break;
-            default:
-                Contract.fail(`Unknown arena type in card data: ${cardData.arena}`);
-        }
 
         // this class is for all card types other than Base and Event (Base is checked in the superclass constructor)
         Contract.assertFalse(this.printedType === CardType.Event);

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -12,9 +12,6 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
     return class WithDamage extends HpClass {
         private _damage?: number;
 
-        /** Used to flag whether the card is in a zone where damage can be applied */
-        private damageEnabled = false;
-
         public get damage(): number {
             this.assertPropertyEnabled(this._damage, 'damage');
             return this._damage;
@@ -75,7 +72,6 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
         }
 
         protected enableDamage(enabledStatus: boolean) {
-            this.damageEnabled = enabledStatus;
             this._damage = enabledStatus ? 0 : null;
         }
     };

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -132,10 +132,29 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         /**
          * This removes an attachment from this card's attachment Array.  It doesn't open any windows for
          * game effects to respond to.
-         * @param {Card} attachment
+         * @param {Card} upgrade
          */
-        public removeAttachment(attachment) {
-            this._upgrades = this.upgrades.filter((card) => card.uuid !== attachment.uuid);
+        public removeUpgrade(upgrade) {
+            this._upgrades = this.upgrades.filter((card) => card.uuid !== upgrade.uuid);
+        }
+
+        public override leavesPlay() {
+            // TODO CAPTURE: use this for capture logic
+            // // Remove any cards underneath from the game
+            // const cardsUnderneath = this.controller.getCardPile(this.uuid).map((a) => a);
+            // if (cardsUnderneath.length > 0) {
+            //     cardsUnderneath.forEach((card) => {
+            //         this.controller.moveCard(card, Location.RemovedFromGame);
+            //     });
+            //     this.game.addMessage(
+            //         '{0} {1} removed from the game due to {2} leaving play',
+            //         cardsUnderneath,
+            //         cardsUnderneath.length === 1 ? 'is' : 'are',
+            //         this
+            //     );
+            // }
+
+            super.leavesPlay();
         }
     };
 }

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -138,6 +138,13 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             this._upgrades = this.upgrades.filter((card) => card.uuid !== upgrade.uuid);
         }
 
+        /** Attach the passed upgrade to this card, ignoring event windows. This should only be used for manual mode or debugging. */
+        public manualAttach(upgrade) {
+            upgrade.moveTo(this.location);
+            this._upgrades.push(upgrade);
+            upgrade.parentCard = this;
+        }
+
         public override leavesPlay() {
             // TODO CAPTURE: use this for capture logic
             // // Remove any cards underneath from the game

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -9,6 +9,8 @@ import { WithDamage } from './Damage';
 import { WithPrintedPower } from './PrintedPower';
 import type { WithPrintedHp } from './PrintedHp';
 import * as EnumHelpers from '../../utils/EnumHelpers';
+import { UpgradeCard } from '../UpgradeCard';
+import AbilityHelper from '../../../AbilityHelper';
 
 export const UnitPropertiesCard = WithUnitProperties(InPlayCard);
 
@@ -25,13 +27,19 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
     const StatsAndDamageClass = WithDamage(WithPrintedPower(BaseClass));
 
     return class AsUnit extends StatsAndDamageClass {
-        // *************************************** PROPERTY GETTERS ***************************************
+        // ************************************* FIELDS AND PROPERTIES *************************************
+        protected _upgrades: UpgradeCard[] = [];
+
         public override get hp(): number {
             return this.getModifiedStatValue(StatType.Hp);
         }
 
         public override get power(): number {
             return this.getModifiedStatValue(StatType.Power);
+        }
+
+        public get upgrades(): UpgradeCard[] {
+            return this._upgrades;
         }
 
         // ****************************************** CONSTRUCTOR ******************************************
@@ -49,14 +57,11 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
         // ***************************************** STAT HELPERS *****************************************
         private getModifiedStatValue(statType: StatType, floor = true, excludeModifiers = []) {
-            const wrappedModifiers = this.getWrappedStatModifiers(excludeModifiers);
+            const wrappedModifiers = this.getStatModifiers(excludeModifiers);
 
             const baseStatValue = StatsModifierWrapper.fromPrintedValues(this);
 
             const stat = wrappedModifiers.reduce((total, wrappedModifier) => total + wrappedModifier.modifier[statType], baseStatValue.modifier[statType]);
-            if (isNaN(stat)) {
-                return 0;
-            }
 
             // TODO EFFECTS: need a check around here somewhere to defeat the unit if effects have brought hp to 0
 
@@ -64,7 +69,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         }
 
         // TODO: add a summary method that logs these modifiers (i.e., the names, amounts, etc.)
-        private getWrappedStatModifiers(exclusions) {
+        private getStatModifiers(exclusions): StatsModifierWrapper[] {
             if (!exclusions) {
                 exclusions = [];
             }
@@ -79,10 +84,12 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             const modifierEffects: IOngoingCardEffect[] = rawEffects.filter((effect) => effect.type === EffectName.ModifyStats);
             const wrappedStatsModifiers = modifierEffects.map((modifierEffect) => StatsModifierWrapper.fromEffect(modifierEffect, this));
 
+            // add stat bonuses from attached upgrades
+            this.upgrades.forEach((upgrade) => wrappedStatsModifiers.push(StatsModifierWrapper.fromPrintedValues(upgrade)));
+
             return wrappedStatsModifiers;
         }
 
-        // TODO UPGRADES: this whole section for managing upgrades on a unit
         // *************************************** UPGRADE HELPERS ***************************************
         /**
          * Checks whether an attachment can be played on a given card.  Intended to be
@@ -100,180 +107,5 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         public removeAttachment(attachment) {
             this._upgrades = this.upgrades.filter((card) => card.uuid !== attachment.uuid);
         }
-
-        // /**
-        //  * Checks 'no attachment' restrictions for this card when attempting to
-        //  * attach the passed attachment card.
-        //  */
-        // public allowAttachment(attachment) {
-        //     if (this.allowedAttachmentTraits.some((trait) => attachment.hasSomeTrait(trait))) {
-        //         return true;
-        //     }
-
-        //     return this.isBlank() || this.allowedAttachmentTraits.length === 0;
-        // }
-
-        // attachmentConditions(properties: AttachmentConditionProps): void {
-        //     const effects = [];
-        //     if (properties.limit) {
-        //         effects.push(Effects.attachmentLimit(properties.limit));
-        //     }
-        //     if (properties.myControl) {
-        //         effects.push(Effects.attachmentMyControlOnly());
-        //     }
-        //     if (properties.opponentControlOnly) {
-        //         effects.push(Effects.attachmentOpponentControlOnly());
-        //     }
-        //     if (properties.unique) {
-        //         effects.push(Effects.attachmentUniqueRestriction());
-        //     }
-        //     if (properties.faction) {
-        //         const factions = Array.isArray(properties.faction) ? properties.faction : [properties.faction];
-        //         effects.push(Effects.attachmentFactionRestriction(factions));
-        //     }
-        //     if (properties.trait) {
-        //         const traits = Array.isArray(properties.trait) ? properties.trait : [properties.trait];
-        //         effects.push(Effects.attachmentTraitRestriction(traits));
-        //     }
-        //     if (properties.limitTrait) {
-        //         const traitLimits = Array.isArray(properties.limitTrait) ? properties.limitTrait : [properties.limitTrait];
-        //         traitLimits.forEach((traitLimit) => {
-        //             const trait = Object.keys(traitLimit)[0];
-        //             effects.push(Effects.attachmentRestrictTraitAmount({ [trait]: traitLimit[trait] }));
-        //         });
-        //     }
-        //     if (properties.cardCondition) {
-        //         effects.push(Effects.attachmentCardCondition(properties.cardCondition));
-        //     }
-        //     if (effects.length > 0) {
-        //         this.persistentEffect({
-        //             location: Location.Any,
-        //             effect: effects
-        //         });
-        //     }
-        // }
-
-        // isAttachmentBonusModifierSwitchActive() {
-        //     const switches = this.getEffectValues(EffectName.SwitchAttachmentSkillModifiers).filter(Boolean);
-        //     // each pair of switches cancels each other. Need an odd number of switches to be active
-        //     return switches.length % 2 === 1;
-        // }
-
-        // applyAttachmentBonus() {
-        //     const militaryBonus = parseInt(this.cardData.military_bonus);
-        //     const politicalBonus = parseInt(this.cardData.political_bonus);
-        //     if (!isNaN(militaryBonus)) {
-        //         this.persistentEffect({
-        //             match: (card) => card === this.parent,
-        //             targetController: RelativePlayer.Any,
-        //             effect: AbilityHelper.effects.attachmentMilitarySkillModifier(() =>
-        //                 this.isAttachmentBonusModifierSwitchActive() ? politicalBonus : militaryBonus
-        //             )
-        //         });
-        //     }
-        //     if (!isNaN(politicalBonus)) {
-        //         this.persistentEffect({
-        //             match: (card) => card === this.parent,
-        //             targetController: RelativePlayer.Any,
-        //             effect: AbilityHelper.effects.attachmentPoliticalSkillModifier(() =>
-        //                 this.isAttachmentBonusModifierSwitchActive() ? militaryBonus : politicalBonus
-        //             )
-        //         });
-        //     }
-        // }
-
-        // checkForIllegalAttachments() {
-        //     let context = this.game.getFrameworkContext(this.controller);
-        //     const illegalAttachments = new Set(
-        //         this.upgrades.filter((attachment) => !this.allowAttachment(attachment) || !attachment.canAttach(this))
-        //     );
-        //     for (const effectCard of this.getEffectValues(EffectName.CannotHaveOtherRestrictedAttachments)) {
-        //         for (const card of this.upgrades) {
-        //             if (card.isRestricted() && card !== effectCard) {
-        //                 illegalAttachments.add(card);
-        //             }
-        //         }
-        //     }
-
-        //     const attachmentLimits = this.upgrades.filter((card) => card.anyEffect(EffectName.AttachmentLimit));
-        //     for (const card of attachmentLimits) {
-        //         let limit = Math.max(...card.getEffectValues(EffectName.AttachmentLimit));
-        //         const matchingAttachments = this.upgrades.filter((attachment) => attachment.id === card.id);
-        //         for (const card of matchingAttachments.slice(0, -limit)) {
-        //             illegalAttachments.add(card);
-        //         }
-        //     }
-
-        //     const frameworkLimitsAttachmentsWithRepeatedNames =
-        //         this.game.gameMode === GameMode.Emerald || this.game.gameMode === GameMode.Obsidian;
-        //     if (frameworkLimitsAttachmentsWithRepeatedNames) {
-        //         for (const card of this.upgrades) {
-        //             const matchingAttachments = this.upgrades.filter(
-        //                 (attachment) =>
-        //                     !attachment.allowDuplicatesOfAttachment &&
-        //                     attachment.id === card.id &&
-        //                     attachment.controller === card.controller
-        //             );
-        //             for (const card of matchingAttachments.slice(0, -1)) {
-        //                 illegalAttachments.add(card);
-        //             }
-        //         }
-        //     }
-
-        //     for (const object of this.upgrades.reduce(
-        //         (array, card) => array.concat(card.getEffectValues(EffectName.AttachmentRestrictTraitAmount)),
-        //         []
-        //     )) {
-        //         for (const trait of Object.keys(object)) {
-        //             const matchingAttachments = this.upgrades.filter((attachment) => attachment.hasSomeTrait(trait));
-        //             for (const card of matchingAttachments.slice(0, -object[trait])) {
-        //                 illegalAttachments.add(card);
-        //             }
-        //         }
-        //     }
-        //     let maximumRestricted = 2 + this.sumEffects(EffectName.ModifyRestrictedAttachmentAmount);
-        //     if (this.upgrades.filter((card) => card.isRestricted()).length > maximumRestricted) {
-        //         this.game.promptForSelect(this.controller, {
-        //             activePromptTitle: 'Choose an attachment to discard',
-        //             waitingPromptTitle: 'Waiting for opponent to choose an attachment to discard',
-        //             cardCondition: (card) => card.parent === this && card.isRestricted(),
-        //             onSelect: (player, card) => {
-        //                 this.game.addMessage(
-        //                     '{0} discards {1} from {2} due to too many Restricted attachments',
-        //                     player,
-        //                     card,
-        //                     card.parent
-        //                 );
-
-        //                 if (illegalAttachments.size > 0) {
-        //                     this.game.addMessage(
-        //                         '{0} {1} discarded from {3} as {2} {1} no longer legally attached',
-        //                         Array.from(illegalAttachments),
-        //                         illegalAttachments.size > 1 ? 'are' : 'is',
-        //                         illegalAttachments.size > 1 ? 'they' : 'it',
-        //                         this
-        //                     );
-        //                 }
-
-        //                 illegalAttachments.add(card);
-        //                 this.game.applyGameAction(context, { discardFromPlay: Array.from(illegalAttachments) });
-        //                 return true;
-        //             },
-        //             source: 'Too many Restricted attachments'
-        //         });
-        //         return true;
-        //     } else if (illegalAttachments.size > 0) {
-        //         this.game.addMessage(
-        //             '{0} {1} discarded from {3} as {2} {1} no longer legally attached',
-        //             Array.from(illegalAttachments),
-        //             illegalAttachments.size > 1 ? 'are' : 'is',
-        //             illegalAttachments.size > 1 ? 'they' : 'it',
-        //             this
-        //         );
-        //         this.game.applyGameAction(context, { discardFromPlay: Array.from(illegalAttachments) });
-        //         return true;
-        //     }
-        //     return false;
-        // }
     };
 }

--- a/server/game/core/cardSelector/SingleCardSelector.js
+++ b/server/game/core/cardSelector/SingleCardSelector.js
@@ -1,5 +1,5 @@
 const BaseCardSelector = require('./BaseCardSelector.js');
-const { CardType } = require('../Constants.js');
+const { CardType, WildcardCardType } = require('../Constants.js');
 
 class SingleCardSelector extends BaseCardSelector {
     constructor(properties) {
@@ -11,7 +11,7 @@ class SingleCardSelector extends BaseCardSelector {
 
     /** @override */
     defaultActivePromptTitle() {
-        if (this.cardTypeFilter.length === 1) {
+        if (this.cardTypeFilter.length === 1 && this.cardTypeFilter[0] !== WildcardCardType.Any) {
             if (this.cardTypeFilter[0] === CardType.Upgrade) {
                 return 'Choose an upgrade';
             }

--- a/server/game/core/event/EventWindow.js
+++ b/server/game/core/event/EventWindow.js
@@ -28,7 +28,7 @@ class EventWindow extends BaseStepWithPipeline {
             new SimpleStep(this.game, () => this.createContingentEvents(), 'createContingentEvents'),
             new SimpleStep(this.game, () => this.preResolutionEffects(), 'preResolutionEffects'),
             new SimpleStep(this.game, () => this.executeHandler(), 'executeHandler'),
-            // new SimpleStep(this.game, () => this.resolveGameState(), 'resolveGameState'),    // TODO EFFECTS: uncomment this (and other places the method is used, + missing ones from l5r)
+            new SimpleStep(this.game, () => this.resolveGameState(), 'resolveGameState'),    // TODO EFFECTS: uncomment this (and other places the method is used, + missing ones from l5r)
             // new SimpleStep(this.game, () => this.checkAdditionalAbilitySteps(), 'checkAdditionalAbilitySteps'),
             new SimpleStep(this.game, () => this.openWindow(AbilityType.Triggered), 'open TriggeredAbility window'),
             new SimpleStep(this.game, () => this.resetCurrentEventWindow(), 'resetCurrentEventWindow')
@@ -101,10 +101,12 @@ class EventWindow extends BaseStepWithPipeline {
         });
     }
 
-    // resolveGameState() {
-    //     this.eventsToExecute = this.eventsToExecute.filter((event) => !event.cancelled);
-    //     this.game.resolveGameState(_.any(this.eventsToExecute, (event) => event.handler), this.eventsToExecute);
-    // }
+    resolveGameState() {
+        this.eventsToExecute = this.eventsToExecute.filter((event) => !event.cancelled);
+
+        // TODO: understand if this needs to be called with the eventsToExecute array
+        this.game.resolveGameState(this.eventsToExecute.some((event) => event.handler), this.eventsToExecute);
+    }
 
     // TODO: what's up with 'then' abilities
     // checkAdditionalAbilitySteps() {

--- a/server/game/core/event/EventWindow.js
+++ b/server/game/core/event/EventWindow.js
@@ -25,12 +25,10 @@ class EventWindow extends BaseStepWithPipeline {
         this.pipeline.initialise([
             new SimpleStep(this.game, () => this.setCurrentEventWindow(), 'setCurrentEventWindow'),
             new SimpleStep(this.game, () => this.checkEventCondition(), 'checkEventCondition'),
-            // new SimpleStep(this.game, () => this.createContingentEvents(), 'createContingentEvents'),
-            // new SimpleStep(this.game, () => this.checkKeywordAbilities(AbilityType.KeywordInterrupt)),
+            new SimpleStep(this.game, () => this.createContingentEvents(), 'createContingentEvents'),
             new SimpleStep(this.game, () => this.preResolutionEffects(), 'preResolutionEffects'),
             new SimpleStep(this.game, () => this.executeHandler(), 'executeHandler'),
-            // new SimpleStep(this.game, () => this.resolveGameState(), 'resolveGameState'),
-            // new SimpleStep(this.game, () => this.checkKeywordAbilities(AbilityType.KeywordReaction)),
+            // new SimpleStep(this.game, () => this.resolveGameState(), 'resolveGameState'),    // TODO EFFECTS: uncomment this (and other places the method is used, + missing ones from l5r)
             // new SimpleStep(this.game, () => this.checkAdditionalAbilitySteps(), 'checkAdditionalAbilitySteps'),
             new SimpleStep(this.game, () => this.openWindow(AbilityType.Triggered), 'open TriggeredAbility window'),
             new SimpleStep(this.game, () => this.resetCurrentEventWindow(), 'resetCurrentEventWindow')
@@ -73,19 +71,18 @@ class EventWindow extends BaseStepWithPipeline {
         }
     }
 
-    // TODO: do we need this?
-    // // This is primarily for LeavesPlayEvents
-    // createContingentEvents() {
-    //     let contingentEvents = [];
-    //     this.events.forEach((event) => {
-    //         contingentEvents = contingentEvents.concat(event.createContingentEvents());
-    //     });
-    //     if (contingentEvents.length > 0) {
-    //         // Exclude current events from the new window, we just want to give players opportunities to respond to the contingent events
-    //         this.queueStep(new TriggeredAbilityWindow(this.game, AbilityType.WouldInterrupt, this, this.events.slice(0)));
-    //         _.each(contingentEvents, (event) => this.addEvent(event));
-    //     }
-    // }
+    /**
+     * Creates any "contingent" events which will happen in the same window as the primary event
+     * but will be resolved after it in order. The main use case for this is upgrades being
+     * defeated at the same time as the parent card holding them.
+     */
+    createContingentEvents() {
+        let contingentEvents = [];
+        this.events.forEach((event) => {
+            contingentEvents = contingentEvents.concat(event.createContingentEvents());
+        });
+        contingentEvents.forEach((event) => this.addEvent(event));
+    }
 
     preResolutionEffects() {
         this.events.forEach((event) => event.preResolutionEffect());
@@ -107,14 +104,6 @@ class EventWindow extends BaseStepWithPipeline {
     // resolveGameState() {
     //     this.eventsToExecute = this.eventsToExecute.filter((event) => !event.cancelled);
     //     this.game.resolveGameState(_.any(this.eventsToExecute, (event) => event.handler), this.eventsToExecute);
-    // }
-
-    // checkKeywordAbilities(abilityType) {
-    //     if(_.isEmpty(this.events)) {
-    //         return;
-    //     }
-
-    //     this.queueStep(new KeywordAbilityWindow(this.game, abilityType, this));
     // }
 
     // TODO: what's up with 'then' abilities

--- a/server/game/core/gameSteps/prompts/AttachUpgradePrompt.ts
+++ b/server/game/core/gameSteps/prompts/AttachUpgradePrompt.ts
@@ -1,0 +1,44 @@
+import * as GameSystems from '../../../gameSystems/GameSystemLibrary';
+import { AbilityContext } from '../../ability/AbilityContext';
+import { UpgradeCard } from '../../card/UpgradeCard';
+import { PlayType, RelativePlayer } from '../../Constants';
+import Game from '../../Game';
+import Player from '../../Player';
+import { UiPrompt } from './UiPrompt';
+
+export class AttachUpgradePrompt extends UiPrompt {
+    public readonly player: Player;
+    public readonly upgradeCard: UpgradeCard;
+    public readonly playType: PlayType;
+
+    public constructor(game: Game, player: Player, upgradeCard: UpgradeCard, playType: PlayType) {
+        super(game);
+        this.player = player;
+        this.upgradeCard = upgradeCard;
+        this.playType = playType;
+    }
+
+    public override continue() {
+        this.game.promptForSelect(this.player, {
+            source: 'Play Upgrade',
+            activePromptTitle: 'Select target for Upgrade',
+            controller: RelativePlayer.Self,
+            gameAction: GameSystems.attachUpgrade({ upgrade: this.upgradeCard }),
+            onSelect: (player, card) => {
+                GameSystems.attachUpgrade({ upgrade: this.upgradeCard }).resolve(card, new AbilityContext({ game: this.game, player: this.player, source: card }));
+                return true;
+            }
+        });
+        return true;
+    }
+
+    // TODO: understand the UiPrompt flow better to figure out how to make these unnecessary
+    public activePrompt(player: Player) {
+        return undefined;
+    }
+
+    public menuCommand(player: Player, arg: string, method: string) {
+        return undefined;
+    }
+}
+

--- a/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
@@ -38,7 +38,7 @@ interface Props {
 
 export const OngoingEffectBuilder = {
     card: {
-        static: (type: EffectName, value) => (game: Game, source: Card, props: Props) =>
+        static: (type: EffectName, value?) => (game: Game, source: Card, props: Props) =>
             new OngoingCardEffect(game, source, props, new StaticOngoingEffectImpl(type, value)),
         dynamic: (type: EffectName, value) => (game: Game, source: Card, props: Props) =>
             new OngoingCardEffect(game, source, props, new DynamicOngoingEffectImpl(type, value)),
@@ -50,13 +50,13 @@ export const OngoingEffectBuilder = {
                 : OngoingEffectBuilder.card.static(type, value))
     },
     player: {
-        static: (type: EffectName, value) => (game: Game, source: Card, props: Props) =>
+        static: (type: EffectName, value?) => (game: Game, source: Card, props: Props) =>
             new OngoingPlayerEffect(game, source, props, new StaticOngoingEffectImpl(type, value)),
         dynamic: (type: EffectName, value) => (game: Game, source: Card, props: Props) =>
             new OngoingPlayerEffect(game, source, props, new DynamicOngoingEffectImpl(type, value)),
         detached: (type: EffectName, value) => (game: Game, source: Card, props: Props) =>
             new OngoingPlayerEffect(game, source, props, new DetachedOngoingEffectImpl(type, value.apply, value.unapply)),
-        flexible: (type: EffectName, value) =>
+        flexible: (type: EffectName, value?) =>
             (typeof value === 'function'
                 ? OngoingEffectBuilder.player.dynamic(type, value)
                 : OngoingEffectBuilder.player.static(type, value))

--- a/server/game/core/ongoingEffect/effectImpl/StatsModifierWrapper.ts
+++ b/server/game/core/ongoingEffect/effectImpl/StatsModifierWrapper.ts
@@ -1,5 +1,5 @@
 import { Card } from '../../card/Card';
-import { UnitCard } from '../../card/CardTypes';
+import { CardWithPrintedHp, CardWithPrintedPower, UnitCard } from '../../card/CardTypes';
 import type { CardType } from '../../Constants';
 import OngoingEffect from '../OngoingEffect';
 import { IOngoingCardEffect } from '../IOngoingCardEffect';
@@ -9,6 +9,10 @@ import { NonLeaderUnitCard } from '../../card/NonLeaderUnitCard';
 import { UnitPropertiesCard } from '../../card/propertyMixins/UnitProperties';
 import Contract from '../../utils/Contract';
 
+/**
+ * A wrapper around a {@link StatsModifier} that has helper methods for creation as well
+ * as additional logging data intended to facilitate displaying stats in the UI
+ */
 export default class StatsModifierWrapper {
     public readonly modifier: StatsModifier;
     public readonly name: string;
@@ -55,27 +59,22 @@ export default class StatsModifierWrapper {
     }
 
     public static fromPrintedValues(card: Card, overrides = false) {
-        if (!Contract.assertTrue(card.isUnit())) {
+        if (
+            !Contract.assertHasProperty(card, 'printedHp') ||
+            !Contract.assertHasProperty(card, 'printedPower')
+        ) {
             return null;
         }
 
+        const description = card.isUpgrade() ? `${card.name} bonus` : `${card.name} base`;
+
         return new this({
-            hp: (card as UnitCard).printedHp,
-            power: (card as UnitCard).printedPower
+            hp: (card as CardWithPrintedHp).printedHp,
+            power: (card as CardWithPrintedPower).printedPower
         },
-        `${card.name} base`,
+        description,
         overrides,
         this.getCardType(card)
         );
     }
-
-    // TODO UPGRADES: should we use this for generating stat modifiers from attached upgrades or use the effect system?
-    // static fromStatusToken(amount: number, name, overrides = false) {
-    //     return new this(
-    //         amount,
-    //         name,
-    //         overrides,
-    //         undefined
-    //     );
-    // }
 }

--- a/server/game/gameSystems/AttachUpgradeSystem.ts
+++ b/server/game/gameSystems/AttachUpgradeSystem.ts
@@ -1,0 +1,130 @@
+import { AbilityContext } from '../core/ability/AbilityContext';
+import { Card } from '../core/card/Card';
+import { UnitCard } from '../core/card/CardTypes';
+import { UpgradeCard } from '../core/card/UpgradeCard';
+import { AbilityRestriction, CardTypeFilter, EventName, WildcardCardType } from '../core/Constants';
+import { CardTargetSystem, ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
+import Contract from '../core/utils/Contract';
+import * as EnumHelpers from '../core/utils/EnumHelpers';
+
+export interface IAttachUpgradeProperties extends ICardTargetSystemProperties {
+    upgrade?: UpgradeCard;
+    takeControl?: boolean;
+    giveControl?: boolean;
+    controlSwitchOptional?: boolean;
+}
+
+export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperties> {
+    public override readonly name = 'attach';
+    public override readonly eventName = EventName.OnUpgradeAttached;
+    protected override readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Unit];
+    protected override readonly defaultProperties: IAttachUpgradeProperties = {
+        takeControl: false,
+        giveControl: false,
+    };
+
+    public override eventHandler(event, additionalProperties = {}): void {
+        const properties = this.generatePropertiesFromContext(event.context, additionalProperties);
+        event.originalLocation = event.card.location;
+
+        if (EnumHelpers.isArena(event.card.location)) {
+            // if the upgrade is being moved, first remove it from its current parent
+            event.card.parentCard.removeAttachment(event.card);
+        } else {
+            event.card.controller.removeCardFromPile(event.card);
+            event.card.new = true;
+            event.card.moveTo(event.parentCard.location);
+        }
+
+        event.parentCard.upgrades.push(event.card);
+        event.card.parentCard = event.parentCard;
+        if (properties.takeControl) {
+            event.card.controller = event.context.player;
+            event.card.updateConstantAbilityContexts();
+        } else if (properties.giveControl) {
+            event.card.controller = event.context.player.opponent;
+            event.card.updateConstantAbilityContexts();
+        }
+    }
+
+    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+        const properties = this.generatePropertiesFromContext(context);
+        if (properties.takeControl) {
+            return [
+                'take control of and attach {2}\'s {1} to {0}',
+                [properties.target, properties.upgrade, properties.upgrade.parentCard]
+            ];
+        } else if (properties.giveControl) {
+            return [
+                'give control of and attach {2}\'s {1} to {0}',
+                [properties.target, properties.upgrade, properties.upgrade.parentCard]
+            ];
+        }
+        return ['attach {1} to {0}', [properties.target, properties.upgrade]];
+    }
+
+    public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        const contextCopy = context.copy({ source: card });
+
+        if (
+            !Contract.assertNotNullLike(context) ||
+            !Contract.assertNotNullLike(context.player) ||
+            !Contract.assertNotNullLike(card) ||
+            !Contract.assertNotNullLike(properties.upgrade)
+        ) {
+            return false;
+        }
+
+        if (!card.isUnit()) {
+            return false;
+        }
+        if (!properties.upgrade.canAttach((card as UnitCard), this.getFinalController(properties, context))) {
+            return false;
+        } else if (
+            !properties.controlSwitchOptional &&
+            properties.takeControl &&
+            properties.upgrade.controller === context.player
+        ) {
+            return false;
+        } else if (
+            !properties.controlSwitchOptional &&
+            properties.giveControl &&
+            properties.upgrade.controller !== context.player
+        ) {
+            return false;
+        } else if (card.hasRestriction(AbilityRestriction.EnterPlay, context)) {
+            return false;
+        } else if (context.player.hasRestriction(AbilityRestriction.PutIntoPlay, contextCopy)) {
+            return false;
+        }
+        return super.canAffect(card, context);
+    }
+
+    public override checkEventCondition(event, additionalProperties): boolean {
+        return this.canAffect(event.parent, event.context, additionalProperties);
+    }
+
+    public override isEventFullyResolved(event, card: Card, context: AbilityContext, additionalProperties): boolean {
+        const { upgrade } = this.generatePropertiesFromContext(context, additionalProperties);
+        return event.parent === card && event.card === upgrade && event.name === this.eventName && !event.cancelled;
+    }
+
+    public override addPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+        const { upgrade } = this.generatePropertiesFromContext(context, additionalProperties);
+        event.name = this.eventName;
+        event.parent = card;
+        event.card = upgrade;
+        event.context = context;
+    }
+
+    private getFinalController(properties, context) {
+        if (properties.takeControl) {
+            return context.player;
+        } else if (properties.giveControl) {
+            return context.player.opponent;
+        }
+
+        return properties.attachment.controller;
+    }
+}

--- a/server/game/gameSystems/AttachUpgradeSystem.ts
+++ b/server/game/gameSystems/AttachUpgradeSystem.ts
@@ -24,6 +24,10 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
     };
 
     public override eventHandler(event, additionalProperties = {}): void {
+        if (!Contract.assertTrue(event.card.isUpgrade()) || !Contract.assertTrue(event.parentCard.isUnit())) {
+            return;
+        }
+
         const properties = this.generatePropertiesFromContext(event.context, additionalProperties);
         event.originalLocation = event.card.location;
 
@@ -82,13 +86,11 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
         if (!properties.upgrade.canAttach((card as UnitCard), this.getFinalController(properties, context))) {
             return false;
         } else if (
-            !properties.controlSwitchOptional &&
             properties.takeControl &&
             properties.upgrade.controller === context.player
         ) {
             return false;
         } else if (
-            !properties.controlSwitchOptional &&
             properties.giveControl &&
             properties.upgrade.controller !== context.player
         ) {
@@ -102,18 +104,18 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
     }
 
     public override checkEventCondition(event, additionalProperties): boolean {
-        return this.canAffect(event.parent, event.context, additionalProperties);
+        return this.canAffect(event.parentCard, event.context, additionalProperties);
     }
 
     public override isEventFullyResolved(event, card: Card, context: AbilityContext, additionalProperties): boolean {
         const { upgrade } = this.generatePropertiesFromContext(context, additionalProperties);
-        return event.parent === card && event.card === upgrade && event.name === this.eventName && !event.cancelled;
+        return event.parentCard === card && event.card === upgrade && event.name === this.eventName && !event.cancelled;
     }
 
     public override addPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
         const { upgrade } = this.generatePropertiesFromContext(context, additionalProperties);
         event.name = this.eventName;
-        event.parent = card;
+        event.parentCard = card;
         event.card = upgrade;
         event.context = context;
     }
@@ -125,6 +127,6 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
             return context.player.opponent;
         }
 
-        return properties.attachment.controller;
+        return properties.upgrade.controller;
     }
 }

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -34,6 +34,6 @@ export class DefeatCardSystem extends CardTargetSystem<IDefeatCardProperties> {
     }
 
     protected override updateEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
-        this.updateLeavesPlayEvent(event, card, context, additionalProperties);
+        this.addLeavesPlayPropertiesToEvent(event, card, context, additionalProperties);
     }
 }

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -2,7 +2,7 @@ import { GameSystem } from '../core/gameSystem/GameSystem';
 import { AbilityContext } from '../core/ability/AbilityContext';
 
 // import { AddTokenAction, AddTokenProperties } from './AddTokenAction';
-// import { AttachAction, AttachActionProperties } from './AttachAction';
+import { AttachUpgradeSystem, IAttachUpgradeProperties } from './AttachUpgradeSystem';
 import { AttackSystem, IAttackProperties } from './AttackSystem';
 // import { CancelAction, CancelActionProperties } from './CancelAction';
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
@@ -64,9 +64,9 @@ type PropsFactory<Props> = Props | ((context: AbilityContext) => Props);
 // export function addToken(propertyFactory: PropsFactory<AddTokenProperties> = {}): GameSystem {
 //     return new AddTokenAction(propertyFactory);
 // }
-// export function attach(propertyFactory: PropsFactory<AttachActionProperties> = {}): GameSystem {
-//     return new AttachAction(propertyFactory);
-// }
+export function attachUpgrade(propertyFactory: PropsFactory<IAttachUpgradeProperties> = {}): GameSystem {
+    return new AttachUpgradeSystem(propertyFactory);
+}
 export function attack(propertyFactory: PropsFactory<IAttackProperties>): GameSystem {
     return new AttackSystem(propertyFactory);
 }

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -58,7 +58,6 @@ export class MoveCardSystem extends CardTargetSystem<IMoveCardProperties> {
         } else if (properties.faceup) { // TODO: add overrides for other card properties (e.g., exhausted)
             card.facedown = false;
         }
-        card.checkForIllegalAttachments();
     }
 
     public override getCostMessage(context: AbilityContext): [string, any[]] {

--- a/server/game/gameSystems/ReturnToHandSystem.ts
+++ b/server/game/gameSystems/ReturnToHandSystem.ts
@@ -35,7 +35,7 @@ export class ReturnToHandSystem extends CardTargetSystem<IReturnToHandProperties
     }
 
     protected override updateEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
-        this.updateLeavesPlayEvent(event, card, context, additionalProperties);
+        this.addLeavesPlayPropertiesToEvent(event, card, context, additionalProperties);
         event.destination = Location.Hand;
     }
 }

--- a/server/game/ongoingEffects/EffectLibrary.ts
+++ b/server/game/ongoingEffects/EffectLibrary.ts
@@ -3,8 +3,6 @@ import { IAbilityLimit } from '../core/ability/AbilityLimit';
 // const Restriction = require('./Effects/restriction.js');
 // const { SuppressEffect } = require('./Effects/SuppressEffect');
 import { OngoingEffectBuilder } from '../core/ongoingEffect/OngoingEffectBuilder';
-// const { attachmentMilitarySkillModifier } = require('./Effects/Library/attachmentMilitarySkillModifier');
-// const { attachmentPoliticalSkillModifier } = require('./Effects/Library/attachmentPoliticalSkillModifier');
 // const { canPlayFromOwn } = require('./Effects/Library/canPlayFromOwn');
 import { cardCannot } from './CardCannot';
 // const { copyCard } = require('./Effects/Library/copyCard');
@@ -123,7 +121,6 @@ export = {
     modifyStats: (modifier: StatsModifier) => OngoingEffectBuilder.card.flexible(EffectName.ModifyStats, modifier),
     // modifyMilitarySkill: (value) => OngoingEffectBuilder.card.flexible(EffectName.ModifyMilitarySkill, value),
     // switchAttachmentSkillModifiers,
-    // attachmentMilitarySkillModifier,
     // modifyMilitarySkillMultiplier: (value) =>
     //     OngoingEffectBuilder.card.flexible(EffectName.ModifyMilitarySkillMultiplier, value),
     // modifyPoliticalSkill: (value) => OngoingEffectBuilder.card.flexible(EffectName.ModifyPoliticalSkill, value),

--- a/server/game/ongoingEffects/EffectLibrary.ts
+++ b/server/game/ongoingEffects/EffectLibrary.ts
@@ -68,6 +68,7 @@ export = {
     //     OngoingEffectBuilder.card.static(EffectName.CannotParticipateAsAttacker, type),
     // cannotParticipateAsDefender: (type = 'both') =>
     //     OngoingEffectBuilder.card.static(EffectName.CannotParticipateAsDefender, type),
+    cannotAttackBase: () => OngoingEffectBuilder.card.static(EffectName.CannotAttackBase),
     cardCannot,
     // changeContributionFunction: (func) => OngoingEffectBuilder.card.static(EffectName.ChangeContributionFunction, func),
     // changeType: (type) => OngoingEffectBuilder.card.static(EffectName.ChangeType, type),

--- a/server/game/ongoingEffects/RestrictionDsl.ts
+++ b/server/game/ongoingEffects/RestrictionDsl.ts
@@ -91,7 +91,7 @@ export const restrictionDsl = {
     // opponentsCharacterAbilitiesWithLowerGlory: (context, effect) =>
     //     context.source.type === CardTypes.Character &&
     //     context.source.controller === getApplyingPlayer(effect).opponent &&
-    //     context.source.glory < effect.context.source.parent.glory,
+    //     context.source.glory < effect.context.source.parentCard.glory,
     // reactions: (context) => context.ability.abilityType === AbilityTypes.Reaction,
     // actionEvents: (context) =>
     //     context.ability.card.type === CardTypes.Event && context.ability.abilityType === AbilityTypes.Action,

--- a/test/helpers/DeckBuilder.js
+++ b/test/helpers/DeckBuilder.js
@@ -97,9 +97,9 @@ class DeckBuilder {
             } else {
                 //Add the card itself
                 inPlayCards.push(card.card);
-                //Add any attachments
-                if (card.attachments) {
-                    inPlayCards.push(...card.attachments);
+                //Add any upgrades
+                if (card.upgrades) {
+                    inPlayCards.push(...card.upgrades);
                 }
             }
         }

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -294,6 +294,17 @@ global.integration = function (definitions) {
                 }
                 this.game.gameMode = GameMode.Premier;
 
+                // if user didn't provide explicit resource cards, create default ones to be added to deck
+                const setDefaultResourceCards = (options) => {
+                    if (options.resources == null) {
+                        options.resources = Array(20).fill('underworld-thug');
+                    } else if (typeof options.resources === 'number') {
+                        options.resources = Array(options.resources).fill('underworld-thug');
+                    }
+                };
+                setDefaultResourceCards(options.player1);
+                setDefaultResourceCards(options.player2);
+
                 // pass decklists to players. they are initialized into real card objects in the startGame() call
                 this.player1.selectDeck(deckBuilder.customDeck(options.player1));
                 this.player2.selectDeck(deckBuilder.customDeck(options.player2));

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -149,7 +149,14 @@ class PlayerInteractionWrapper {
         return this.player.resources;
     }
 
-    // TODO: helper method for this
+    /**
+     * Sets the player's resource count to the specified number, using
+     * a default card name
+     */
+    setResourceCount(count) {
+        this.setResourceCards(Array(count).fill('underworld-thug'));
+    }
+
     /**
      * List of objects describing cards in resource area
      * Either as Object:

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -129,7 +129,7 @@ class PlayerInteractionWrapper {
                 });
                 // Attach to the card
                 upgrades.forEach((upgrade) => {
-                    this.player.attach(upgrade, card);
+                    card.manualAttach(upgrade);
                 });
             }
             if (options.damage !== undefined) {

--- a/test/server/actions/PlayUnitFromHand.spec.js
+++ b/test/server/actions/PlayUnitFromHand.spec.js
@@ -6,7 +6,7 @@ describe('Play unit from hand', function() {
                     phase: 'action',
                     player1: {
                         hand: ['cartel-spacer', 'first-legion-snowtrooper', 'battlefield-marine'],
-                        resources: ['atst', 'atst', 'atst', 'atst', 'atst', 'atst'],
+                        resources: 6,   // TODO THIS PR: change all existing tests to reflect resource changes
                         leader: 'boba-fett#collecting-the-bounty',
                         base: 'jabbas-palace'
                     },

--- a/test/server/actions/PlayUpgradeFromHand.spec.js
+++ b/test/server/actions/PlayUpgradeFromHand.spec.js
@@ -5,10 +5,9 @@ describe('Entrenched', function() {
                 this.setupTest({
                     phase: 'action',
                     player1: {
-                        hand: ['entrenched', 'academy-training', 'resilient'],
+                        hand: ['entrenched', 'academy-training', 'resilient', 'foundling'],
                         groundArena: ['wampa'],
-                        spaceArena: ['tieln-fighter'],
-                        leader: ['luke-skywalker#faithful-friend']
+                        spaceArena: ['tieln-fighter']
                     },
                     player2: {
                         spaceArena: ['bright-hope#the-last-transport']
@@ -21,19 +20,97 @@ describe('Entrenched', function() {
                 this.wampa = this.player1.findCardByName('wampa');
                 this.tieLn = this.player1.findCardByName('tieln-fighter');
                 this.brightHope = this.player2.findCardByName('bright-hope#the-last-transport');
-                this.p1Base = this.player2.base;
-                this.p2Base = this.player2.base;
 
                 this.noMoreActions();
             });
 
             it('is played, it should be able to be attached to any ground or space unit and apply a stat bonus to it', function () {
+                // upgrade attaches to friendly ground unit
                 this.player1.clickCard(this.entrenched);
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.upgrades).toContain(this.entrenched);
-                expect(this.wampa.hp).toBe(8);
                 expect(this.wampa.power).toBe(7);
+                expect(this.wampa.hp).toBe(8);
+
+                this.player2.passAction();
+
+                // upgrade attaches to friendly space unit
+                this.player1.clickCard(this.academyTraining);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                this.player1.clickCard(this.tieLn);
+                expect(this.tieLn.upgrades).toContain(this.academyTraining);
+                expect(this.tieLn.power).toBe(4);
+                expect(this.tieLn.hp).toBe(3);
+
+                this.player2.passAction();
+
+                // upgrade attaches to friendly space unit
+                this.player1.clickCard(this.resilient);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                this.player1.clickCard(this.brightHope);
+                expect(this.brightHope.upgrades).toContain(this.resilient);
+                expect(this.brightHope.power).toBe(2);
+                expect(this.brightHope.hp).toBe(9);
+            });
+
+            it('is attached, it should stack bonuses with other applied upgrades', function () {
+                // attach first upgrade
+                this.player1.clickCard(this.entrenched);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                this.player1.clickCard(this.wampa);
+                expect(this.wampa.upgrades).toContain(this.entrenched);
+                expect(this.wampa.power).toBe(7);
+                expect(this.wampa.hp).toBe(8);
+
+                this.player2.passAction();
+
+                // attach second upgrade
+                this.player1.clickCard(this.academyTraining);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                this.player1.clickCard(this.wampa);
+                expect(this.wampa.upgrades).toContain(this.academyTraining);
+                expect(this.wampa.upgrades).toContain(this.entrenched);
+                expect(this.wampa.power).toBe(9);
+                expect(this.wampa.hp).toBe(10);
+            });
+
+            it('is attached, its stat bonuses should be correctly applied during combat', function () {
+                // attach upgrade
+                this.player1.clickCard(this.entrenched);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                this.player1.clickCard(this.tieLn);
+                expect(this.tieLn.upgrades).toContain(this.entrenched);
+                expect(this.tieLn.power).toBe(5);
+                expect(this.tieLn.hp).toBe(4);
+
+                this.player2.passAction();
+
+                // attack unit
+                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.brightHope);
+                expect(this.brightHope.damage).toBe(5);
+                expect(this.tieLn.damage).toBe(2);
+            });
+
+            it('is attached and the owner is defeated, the upgrade should also be defeated', function () {
+                // attach upgrade
+                this.player1.clickCard(this.entrenched);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                this.player1.clickCard(this.tieLn);
+                expect(this.tieLn.upgrades).toContain(this.entrenched);
+                expect(this.tieLn.power).toBe(5);
+                expect(this.tieLn.hp).toBe(4);
+
+                this.tieLn.damage = 3;
+                this.player2.passAction();
+
+                // attack unit
+                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.brightHope);
+                expect(this.brightHope.damage).toBe(5);
+                expect(this.tieLn.location).toBe('discard');
+                expect(this.entrenched.location).toBe('discard');
             });
         });
     });

--- a/test/server/actions/PlayUpgradeFromHand.spec.js
+++ b/test/server/actions/PlayUpgradeFromHand.spec.js
@@ -1,0 +1,40 @@
+describe('Entrenched', function() {
+    integration(function() {
+        describe('When an upgrade', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['entrenched', 'academy-training', 'resilient'],
+                        groundArena: ['wampa'],
+                        spaceArena: ['tieln-fighter'],
+                        leader: ['luke-skywalker#faithful-friend']
+                    },
+                    player2: {
+                        spaceArena: ['bright-hope#the-last-transport']
+                    }
+                });
+
+                this.entrenched = this.player1.findCardByName('entrenched');
+                this.academyTraining = this.player1.findCardByName('academy-training');
+                this.resilient = this.player1.findCardByName('resilient');
+                this.wampa = this.player1.findCardByName('wampa');
+                this.tieLn = this.player1.findCardByName('tieln-fighter');
+                this.brightHope = this.player2.findCardByName('bright-hope#the-last-transport');
+                this.p1Base = this.player2.base;
+                this.p2Base = this.player2.base;
+
+                this.noMoreActions();
+            });
+
+            it('is played, it should be able to be attached to any ground or space unit and apply a stat bonus to it', function () {
+                this.player1.clickCard(this.entrenched);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                this.player1.clickCard(this.wampa);
+                expect(this.wampa.upgrades).toContain(this.entrenched);
+                expect(this.wampa.hp).toBe(8);
+                expect(this.wampa.power).toBe(7);
+            });
+        });
+    });
+});

--- a/test/server/actions/PlayUpgradeFromHand.spec.js
+++ b/test/server/actions/PlayUpgradeFromHand.spec.js
@@ -1,6 +1,6 @@
 describe('Entrenched', function() {
     integration(function() {
-        describe('When an upgrade', function() {
+        describe('When an upgrade is played,', function() {
             beforeEach(function () {
                 this.setupTest({
                     phase: 'action',
@@ -24,7 +24,7 @@ describe('Entrenched', function() {
                 this.noMoreActions();
             });
 
-            it('is played, it should be able to be attached to any ground or space unit and apply a stat bonus to it', function () {
+            it('it should be able to be attached to any ground or space unit and apply a stat bonus to it', function () {
                 // upgrade attaches to friendly ground unit
                 this.player1.clickCard(this.entrenched);
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
@@ -53,61 +53,57 @@ describe('Entrenched', function() {
                 expect(this.brightHope.power).toBe(2);
                 expect(this.brightHope.hp).toBe(9);
             });
+        });
 
-            it('is attached, it should stack bonuses with other applied upgrades', function () {
-                // attach first upgrade
-                this.player1.clickCard(this.entrenched);
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
-                this.player1.clickCard(this.wampa);
-                expect(this.wampa.upgrades).toContain(this.entrenched);
-                expect(this.wampa.power).toBe(7);
-                expect(this.wampa.hp).toBe(8);
+        describe('When an upgrade is attached,', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['foundling'],
+                        groundArena: [{ card: 'wampa', upgrades: ['academy-training'] }],
+                        spaceArena: [{ card: 'tieln-fighter', upgrades: ['entrenched'] }]
+                    },
+                    player2: {
+                        spaceArena: ['bright-hope#the-last-transport']
+                    }
+                });
 
-                this.player2.passAction();
+                this.academyTraining = this.player1.findCardByName('academy-training');
+                this.foundling = this.player1.findCardByName('foundling');
+                this.entrenched = this.player1.findCardByName('entrenched');
+                this.wampa = this.player1.findCardByName('wampa');
+                this.tieLn = this.player1.findCardByName('tieln-fighter');
+                this.brightHope = this.player2.findCardByName('bright-hope#the-last-transport');
 
-                // attach second upgrade
-                this.player1.clickCard(this.academyTraining);
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
-                this.player1.clickCard(this.wampa);
-                expect(this.wampa.upgrades).toContain(this.academyTraining);
-                expect(this.wampa.upgrades).toContain(this.entrenched);
-                expect(this.wampa.power).toBe(9);
-                expect(this.wampa.hp).toBe(10);
+                this.noMoreActions();
             });
 
-            it('is attached, its stat bonuses should be correctly applied during combat', function () {
-                // attach upgrade
-                this.player1.clickCard(this.entrenched);
+
+            it('it should stack bonuses with other applied upgrades', function () {
+                this.player1.clickCard(this.foundling);
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
-                this.player1.clickCard(this.tieLn);
-                expect(this.tieLn.upgrades).toContain(this.entrenched);
-                expect(this.tieLn.power).toBe(5);
-                expect(this.tieLn.hp).toBe(4);
+                this.player1.clickCard(this.wampa);
 
-                this.player2.passAction();
+                expect(this.wampa.upgrades).toContain(this.academyTraining);
+                expect(this.wampa.upgrades).toContain(this.foundling);
+                expect(this.wampa.power).toBe(7);
+                expect(this.wampa.hp).toBe(8);
+            });
 
-                // attack unit
+            it('its stat bonuses should be correctly applied during combat', function () {
                 this.player1.clickCard(this.tieLn);
                 this.player1.clickCard(this.brightHope);
                 expect(this.brightHope.damage).toBe(5);
                 expect(this.tieLn.damage).toBe(2);
             });
 
-            it('is attached and the owner is defeated, the upgrade should also be defeated', function () {
-                // attach upgrade
-                this.player1.clickCard(this.entrenched);
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
-                this.player1.clickCard(this.tieLn);
-                expect(this.tieLn.upgrades).toContain(this.entrenched);
-                expect(this.tieLn.power).toBe(5);
-                expect(this.tieLn.hp).toBe(4);
-
+            it('and the owner is defeated, the upgrade should also be defeated', function () {
                 this.tieLn.damage = 3;
-                this.player2.passAction();
 
-                // attack unit
                 this.player1.clickCard(this.tieLn);
                 this.player1.clickCard(this.brightHope);
+
                 expect(this.brightHope.damage).toBe(5);
                 expect(this.tieLn.location).toBe('discard');
                 expect(this.entrenched.location).toBe('discard');

--- a/test/server/actions/UnitAttack.spec.js
+++ b/test/server/actions/UnitAttack.spec.js
@@ -36,8 +36,7 @@ describe('Basic attack', function() {
 
                 // TODO: test helper for managing attacks
                 // can target opponent's ground units and base but not space units
-                expect(this.player1).toBeAbleToSelectAllOf([this.atrt, this.enfysNest, this.p2Base]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.allianceXWing, this.wampa, this.cartelSpacer, this.p1Base]);
+                expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.enfysNest, this.p2Base]);
             });
 
             it('from space arena to another unit in the space arena, attack should resolve correctly', function () {

--- a/test/server/cardImplementations/01_SOR/2-1BSurgicalDroid.spec.js
+++ b/test/server/cardImplementations/01_SOR/2-1BSurgicalDroid.spec.js
@@ -33,12 +33,11 @@ describe('2-1B Surgical Droid', function() {
                 // Attack
                 this.player1.clickCard(this.surgicalDroid);
                 expect(this.surgicalDroid.location).toBe('ground arena');
-                expect(this.player1).toBeAbleToSelectAllOf([this.p2Base, this.wampa]);
+                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.wampa]);
                 this.player1.clickCard(this.p2Base);
 
                 // Healing Target
-                expect(this.player1).toBeAbleToSelectAllOf([this.r2d2, this.c3p0, this.wampa]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.surgicalDroid]);
+                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3p0, this.wampa]);
                 this.player1.clickCard(this.c3p0);
 
                 // Confirm Results
@@ -50,12 +49,11 @@ describe('2-1B Surgical Droid', function() {
                 // Attack
                 this.player1.clickCard(this.surgicalDroid);
                 expect(this.surgicalDroid.location).toBe('ground arena');
-                expect(this.player1).toBeAbleToSelectAllOf([this.p2Base, this.wampa]);
+                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.wampa]);
                 this.player1.clickCard(this.p2Base);
 
                 // Healing Target
-                expect(this.player1).toBeAbleToSelectAllOf([this.r2d2, this.c3p0, this.wampa]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.surgicalDroid]);
+                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3p0, this.wampa]);
                 this.player1.clickCard(this.r2d2);
 
                 // Confirm Results
@@ -68,12 +66,11 @@ describe('2-1B Surgical Droid', function() {
                 this.player1.clickCard(this.surgicalDroid);
                 expect(this.wampa.damage).toBe(2);
                 expect(this.surgicalDroid.location).toBe('ground arena');
-                expect(this.player1).toBeAbleToSelectAllOf([this.p2Base, this.wampa]);
+                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.wampa]);
                 this.player1.clickCard(this.p2Base);
 
                 // Healing Target
-                expect(this.player1).toBeAbleToSelectAllOf([this.r2d2, this.c3p0, this.wampa]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.surgicalDroid]);
+                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3p0, this.wampa]);
                 this.player1.clickCard(this.wampa);
 
                 // Confirm Results
@@ -84,8 +81,8 @@ describe('2-1B Surgical Droid', function() {
             it('surgical droid ability can be passed', function () {
                 expect(this.r2d2.damage).toBe(3);
                 this.player1.clickCard(this.surgicalDroid);
-                expect(this.player1).toBeAbleToSelectAllOf([this.p2Base]);
                 this.player1.clickCard(this.p2Base);
+
                 this.player1.clickPrompt('Pass ability');
                 expect(this.surgicalDroid.exhausted).toBe(true);
                 expect(this.r2d2.damage).toBe(3);

--- a/test/server/cardImplementations/01_SOR/DeathTrooper.spec.js
+++ b/test/server/cardImplementations/01_SOR/DeathTrooper.spec.js
@@ -36,8 +36,7 @@ describe('Death Trooper', function() {
             it('cannot be passed', function () {
                 // Play Death Trooper
                 this.player1.clickCard(this.deathTrooper);
-                expect(this.player1).toBeAbleToSelectAllOf([this.pykeSentinel, this.deathTrooper]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.interceptor, this.cartelSpacer, this.wampa, this.superlaserTech]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.deathTrooper]);
                 expect(this.player1).not.toHavePassAbilityPrompt();
             });
 
@@ -46,14 +45,12 @@ describe('Death Trooper', function() {
                 this.player1.clickCard(this.deathTrooper);
 
                 // Choose Friendly
-                expect(this.player1).toBeAbleToSelectAllOf([this.pykeSentinel, this.deathTrooper]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.interceptor, this.cartelSpacer, this.wampa, this.superlaserTech]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.deathTrooper]);
                 expect(this.player1).not.toHavePassAbilityPrompt();
                 this.player1.clickCard(this.deathTrooper);
 
                 // Choose Enemy
-                expect(this.player1).toBeAbleToSelectAllOf([this.wampa, this.superlaserTech]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.pykeSentinel, this.deathTrooper, this.interceptor, this.cartelSpacer]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.superlaserTech]);
                 this.player1.clickCard(this.wampa);
                 expect(this.deathTrooper.damage).toEqual(2);
                 expect(this.wampa.damage).toEqual(2);
@@ -65,7 +62,7 @@ describe('Death Trooper', function() {
             //     this.player1.clickCard(this.deathTrooper);
 
             //     // Choose Friendly
-            //     expect(this.player1).toBeAbleToSelectAllOf([this.pykeSentinel, this.deathTrooper]);
+            //     expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.deathTrooper]);
             //     expect(this.player1).not.toHavePassAbilityPrompt();
             //     this.player1.clickCard(this.deathTrooper);
             //     expect(this.deathTrooper.damage).toEqual(2);

--- a/test/server/cardImplementations/01_SOR/Entrenched.spec.js
+++ b/test/server/cardImplementations/01_SOR/Entrenched.spec.js
@@ -1,0 +1,33 @@
+describe('Entrenched', function() {
+    integration(function() {
+        describe('Entrenched\'s ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['entrenched'],
+                        groundArena: ['wampa'],
+                        spaceArena: ['tieln-fighter'],
+                        leader: ['luke-skywalker#faithful-friend']
+                    },
+                    player2: {
+                        spaceArena: ['bright-hope#the-last-transport']
+                    }
+                });
+
+                this.entrenched = this.player1.findCardByName('entrenched');
+                this.wampa = this.player1.findCardByName('wampa');
+                this.tieLn = this.player1.findCardByName('tieln-fighter');
+                this.cartelSpacer = this.player2.findCardByName('bright-hope#the-last-transport');
+                this.p2Base = this.player2.base;
+
+                this.noMoreActions();
+            });
+
+            it('should prevent a unit with no opposing arena units from being able to attack', function () {
+                this.player1.clickCard(this.entrenched);
+                expect(this.player1).toHavePrompt('ground arena');
+            });
+        });
+    });
+});

--- a/test/server/cardImplementations/01_SOR/Entrenched.spec.js
+++ b/test/server/cardImplementations/01_SOR/Entrenched.spec.js
@@ -5,9 +5,8 @@ describe('Entrenched', function() {
                 this.setupTest({
                     phase: 'action',
                     player1: {
-                        // hand: ['entrenched'],
                         groundArena: [{ card: 'wampa', upgrades: ['entrenched'] }],
-                        spaceArena: ['tieln-fighter']
+                        spaceArena: [{ card: 'tieln-fighter', upgrades: ['entrenched'] }],
                     },
                     player2: {
                         spaceArena: ['bright-hope#the-last-transport']
@@ -17,26 +16,57 @@ describe('Entrenched', function() {
                 this.entrenched = this.player1.findCardByName('entrenched');
                 this.wampa = this.player1.findCardByName('wampa');
                 this.tieLn = this.player1.findCardByName('tieln-fighter');
-                this.cartelSpacer = this.player2.findCardByName('bright-hope#the-last-transport');
+                this.brightHope = this.player2.findCardByName('bright-hope#the-last-transport');
                 this.p1Base = this.player2.base;
                 this.p2Base = this.player2.base;
 
                 this.noMoreActions();
             });
 
-            // it('should prevent a unit from being able to attack base', function () {
-            //     // play upgrade
-            //     this.player1.clickCard(this.entrenched);
-            //     this.player1.clickCard(this.tieLn);
+            it('should prevent a unit from being able to attack base', function () {
+                this.player1.clickCard(this.tieLn);
 
-            //     this.player2.passAction();
-
-            //     // attack with wampa
-            //     expect(this.wampa).not.toHaveAvailableActionWhenClickedInActionPhaseBy(this.player1);
-            // });
+                // attack resolved automatically since there's only one legal target
+                expect(this.brightHope.damage).toBe(5);
+                expect(this.tieLn.damage).toBe(2);
+            });
 
             it('should prevent a unit with no opposing arena units from having the option to attack', function () {
                 expect(this.wampa).not.toHaveAvailableActionWhenClickedInActionPhaseBy(this.player1);
+            });
+        });
+
+        describe('Entrenched\'s ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['entrenched'],
+                        spaceArena: ['bright-hope#the-last-transport']
+                    },
+                    player2: {
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+
+                this.entrenched = this.player1.findCardByName('entrenched');
+                this.brightHope = this.player1.findCardByName('bright-hope#the-last-transport');
+                this.tieLn = this.player2.findCardByName('tieln-fighter');
+                this.p1Base = this.player2.base;
+                this.p2Base = this.player2.base;
+
+                this.noMoreActions();
+            });
+
+            it('should work on an opponent\'s unit', function () {
+                // play entrenched on opponent's card
+                this.player1.clickCard(this.entrenched);
+                this.player1.clickCard(this.tieLn);
+
+                // perform attack, resolves automatically since there's only one legal target
+                this.player2.clickCard(this.tieLn);
+                expect(this.brightHope.damage).toBe(5);
+                expect(this.tieLn.damage).toBe(2);
             });
         });
     });

--- a/test/server/cardImplementations/01_SOR/Entrenched.spec.js
+++ b/test/server/cardImplementations/01_SOR/Entrenched.spec.js
@@ -19,6 +19,7 @@ describe('Entrenched', function() {
                 this.wampa = this.player1.findCardByName('wampa');
                 this.tieLn = this.player1.findCardByName('tieln-fighter');
                 this.cartelSpacer = this.player2.findCardByName('bright-hope#the-last-transport');
+                this.p1Base = this.player2.base;
                 this.p2Base = this.player2.base;
 
                 this.noMoreActions();
@@ -26,7 +27,7 @@ describe('Entrenched', function() {
 
             it('should prevent a unit with no opposing arena units from being able to attack', function () {
                 this.player1.clickCard(this.entrenched);
-                expect(this.player1).toHavePrompt('ground arena');
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn]);
             });
         });
     });

--- a/test/server/cardImplementations/01_SOR/Entrenched.spec.js
+++ b/test/server/cardImplementations/01_SOR/Entrenched.spec.js
@@ -5,10 +5,9 @@ describe('Entrenched', function() {
                 this.setupTest({
                     phase: 'action',
                     player1: {
-                        hand: ['entrenched'],
-                        groundArena: ['wampa'],
-                        spaceArena: ['tieln-fighter'],
-                        leader: ['luke-skywalker#faithful-friend']
+                        // hand: ['entrenched'],
+                        groundArena: [{ card: 'wampa', upgrades: ['entrenched'] }],
+                        spaceArena: ['tieln-fighter']
                     },
                     player2: {
                         spaceArena: ['bright-hope#the-last-transport']
@@ -25,9 +24,19 @@ describe('Entrenched', function() {
                 this.noMoreActions();
             });
 
-            it('should prevent a unit with no opposing arena units from being able to attack', function () {
-                this.player1.clickCard(this.entrenched);
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn]);
+            // it('should prevent a unit from being able to attack base', function () {
+            //     // play upgrade
+            //     this.player1.clickCard(this.entrenched);
+            //     this.player1.clickCard(this.tieLn);
+
+            //     this.player2.passAction();
+
+            //     // attack with wampa
+            //     expect(this.wampa).not.toHaveAvailableActionWhenClickedInActionPhaseBy(this.player1);
+            // });
+
+            it('should prevent a unit with no opposing arena units from having the option to attack', function () {
+                expect(this.wampa).not.toHaveAvailableActionWhenClickedInActionPhaseBy(this.player1);
             });
         });
     });

--- a/test/server/cardImplementations/01_SOR/FleetLieutenant.spec.js
+++ b/test/server/cardImplementations/01_SOR/FleetLieutenant.spec.js
@@ -31,12 +31,10 @@ describe('Fleet Lieutenant', function() {
             it('should allowing triggering an attack by a unit when played', function () {
                 this.player1.clickCard(this.fleetLieutenant);
                 expect(this.fleetLieutenant.location).toBe('ground arena');
-                expect(this.player1).toBeAbleToSelectAllOf([this.wampa, this.monMothma]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.p1Base, this.p2Base, this.peacekeeper, this.cartelSpacer]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.monMothma]);
 
                 this.player1.clickCard(this.wampa);
-                expect(this.player1).toBeAbleToSelectAllOf([this.p2Base, this.peacekeeper]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.p1Base, this.wampa, this.monMothma, this.cartelSpacer]);
+                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.peacekeeper]);
 
                 this.player1.clickCard(this.peacekeeper);
                 expect(this.wampa.exhausted).toBe(true);

--- a/test/server/cardImplementations/01_SOR/SabineWrenExplosivesArtist.spec.js
+++ b/test/server/cardImplementations/01_SOR/SabineWrenExplosivesArtist.spec.js
@@ -31,8 +31,7 @@ describe('Sabine Wren, Explosives Artist', function() {
                 this.player2.setActivePlayer();
                 this.player2.clickCard(this.wampa);
 
-                expect(this.player2).toBeAbleToSelectAllOf([this.marine, this.p1Base]);
-                expect(this.player2).not.toBeAbleToSelect(this.sabine);
+                expect(this.player2).toBeAbleToSelectExactly([this.marine, this.p1Base]);
             });
 
             it('should be targetable when less than 3 friendly aspects are in play', function () {
@@ -40,7 +39,7 @@ describe('Sabine Wren, Explosives Artist', function() {
                 this.player2.setActivePlayer();
                 this.player2.clickCard(this.wampa);
 
-                expect(this.player2).toBeAbleToSelectAllOf([this.marine, this.p1Base, this.sabine]);
+                expect(this.player2).toBeAbleToSelectExactly([this.marine, this.p1Base, this.sabine]);
             });
         });
     });

--- a/test/server/cardImplementations/01_SOR/SnowtrooperLieutenant.spec.js
+++ b/test/server/cardImplementations/01_SOR/SnowtrooperLieutenant.spec.js
@@ -31,12 +31,10 @@ describe('Snowtrooper Lieutenant', function() {
             it('should allowing triggering an attack by a unit when played', function () {
                 this.player1.clickCard(this.snowtrooperLieutenant);
                 expect(this.snowtrooperLieutenant.location).toBe('ground arena');
-                expect(this.player1).toBeAbleToSelectAllOf([this.wampa, this.piett]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.p1Base, this.p2Base, this.peacekeeper, this.cartelSpacer]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.piett]);
 
                 this.player1.clickCard(this.wampa);
-                expect(this.player1).toBeAbleToSelectAllOf([this.p2Base, this.peacekeeper]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.p1Base, this.wampa, this.piett, this.cartelSpacer]);
+                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.peacekeeper]);
 
                 this.player1.clickCard(this.peacekeeper);
                 expect(this.wampa.exhausted).toBe(true);

--- a/test/server/cardImplementations/02_SHD/GroguIrresistible.spec.js
+++ b/test/server/cardImplementations/02_SHD/GroguIrresistible.spec.js
@@ -31,8 +31,7 @@ describe('Grogu, Irresistible', function() {
                 this.player1.clickPrompt('Exhaust an enemy unit');
 
                 // can target opponent's units only
-                expect(this.player1).toBeAbleToSelectAllOf([this.atrt, this.enfysNest]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.p1Base, this.p2Base, this.grogu, this.wampa]);
+                expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.enfysNest]);
 
                 this.player1.clickCard(this.enfysNest);
                 expect(this.grogu.exhausted).toBe(true);

--- a/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
+++ b/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
@@ -60,9 +60,7 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
                 this.player1.clickPrompt('Deal 1 damage to a ground unit');
 
                 // can target any ground unit
-                // TODO BUG: crumb itself is also selectable and it shouldn't be
-                // expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.wampa]);
-                expect(this.player1).toBeAbleToSelectAllOf([this.atrt, this.wampa]);
+                expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.wampa]);
 
                 this.player1.clickCard(this.atrt);
                 expect(this.atrt.damage).toBe(1);

--- a/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
+++ b/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
@@ -60,8 +60,9 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
                 this.player1.clickPrompt('Deal 1 damage to a ground unit');
 
                 // can target any ground unit
-                // TODO THIS PR: fix this bug
-                expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.wampa]);
+                // TODO BUG: crumb itself is also selectable and it shouldn't be
+                // expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.wampa]);
+                expect(this.player1).toBeAbleToSelectAllOf([this.atrt, this.wampa]);
 
                 this.player1.clickCard(this.atrt);
                 expect(this.atrt.damage).toBe(1);

--- a/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
+++ b/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
@@ -60,8 +60,8 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
                 this.player1.clickPrompt('Deal 1 damage to a ground unit');
 
                 // can target any ground unit
-                expect(this.player1).toBeAbleToSelectAllOf([this.atrt, this.wampa]);
-                expect(this.player1).toBeAbleToSelectNoneOf([this.player1.base, this.player2.base, this.cartelSpacer]);
+                // TODO THIS PR: fix this bug
+                expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.wampa]);
 
                 this.player1.clickCard(this.atrt);
                 expect(this.atrt.damage).toBe(1);


### PR DESCRIPTION
Upgrades are now working, added tests of play upgrade from hand and Entrenched.

Their capability is still somewhat limited since the majority of them rely on the GainAbility effect to add an ability to the owning card, will work on that in a future PR.

Also improved the test infrastructure somewhat and fixed a bug that was caught in Salacious Crumb.