### PR TITLE
Address some common frustrations with test infra

### DIFF
--- a/test/helpers/DeckBuilder.js
+++ b/test/helpers/DeckBuilder.js
@@ -86,6 +86,10 @@ class DeckBuilder {
 
     getNamedCardsInPlayerEntry(playerEntry) {
         let namedCards = [];
+        if (typeof playerEntry === 'number' || typeof playerEntry == null) {
+            return [];
+        }
+
         if (typeof playerEntry === 'string') {
             namedCards = namedCards.concat(playerEntry);
         } else if ('card' in playerEntry) {
@@ -95,7 +99,7 @@ class DeckBuilder {
             }
         } else if (Array.isArray(playerEntry)) {
             playerEntry.forEach((card) => namedCards = namedCards.concat(this.getNamedCardsInPlayerEntry(card)));
-        } else if (playerEntry != null) {
+        } else {
             throw new Error(`Unknown test card specifier format: '${playerObject}'`);
         }
         return namedCards;

--- a/test/helpers/DeckBuilder.js
+++ b/test/helpers/DeckBuilder.js
@@ -5,7 +5,8 @@ const path = require('path');
 const defaultLeader = { 1: 'darth-vader#dark-lord-of-the-sith', 2: 'luke-skywalker#faithful-friend' };
 const defaultBase = { 1: 'kestro-city', 2: 'administrators-tower' };
 const deckFillerCard = 'underworld-thug';
-const deckBufferSize = 8; // buffer decks to prevent re-shuffling
+const defaultResourceCount = 20;
+const defaultDeckSize = 8; // buffer decks to prevent re-shuffling
 
 class DeckBuilder {
     constructor() {
@@ -41,15 +42,16 @@ class DeckBuilder {
         }
 
         let allCards = [];
-        let deckSize = deckBufferSize;
         let inPlayCards = [];
+
+        const namedCards = this.getAllNamedCards(playerCards);
 
         allCards.push(playerCards.leader ? playerCards.leader : defaultLeader[playerNumber]);
         allCards.push(playerCards.base ? playerCards.base : defaultBase[playerNumber]);
 
         // if user didn't provide explicit resource cards, create default ones to be added to deck
-        playerCards.resources = this.padCardListIfNeeded(playerCards.resources, 20);
-        playerCards.deck = this.padCardListIfNeeded(playerCards.deck, 8);
+        playerCards.resources = this.padCardListIfNeeded(playerCards.resources, defaultResourceCount);
+        playerCards.deck = this.padCardListIfNeeded(playerCards.deck, defaultDeckSize);
 
         allCards.push(...playerCards.resources);
         allCards.push(...playerCards.deck);
@@ -71,7 +73,32 @@ class DeckBuilder {
         //Collect all the cards together
         allCards = allCards.concat(inPlayCards);
 
-        return this.buildDeck(allCards);
+        return [this.buildDeck(allCards), namedCards];
+    }
+
+    getAllNamedCards(playerObject) {
+        let namedCards = [];
+        for (const key in playerObject) {
+            namedCards = namedCards.concat(this.getNamedCardsInPlayerEntry(playerObject[key]));
+        }
+        return namedCards;
+    }
+
+    getNamedCardsInPlayerEntry(playerEntry) {
+        let namedCards = [];
+        if (typeof playerEntry === 'string') {
+            namedCards = namedCards.concat(playerEntry);
+        } else if ('card' in playerEntry) {
+            namedCards.push(playerEntry.card);
+            if ('upgrades' in playerEntry) {
+                namedCards = namedCards.concat(this.getNamedCardsInPlayerEntry(playerEntry.upgrades));
+            }
+        } else if (Array.isArray(playerEntry)) {
+            playerEntry.forEach((card) => namedCards = namedCards.concat(this.getNamedCardsInPlayerEntry(card)));
+        } else if (playerEntry != null) {
+            throw new Error(`Unknown test card specifier format: '${playerObject}'`);
+        }
+        return namedCards;
     }
 
     padCardListIfNeeded(cardList, defaultCount) {

--- a/test/helpers/GameFlowWrapper.js
+++ b/test/helpers/GameFlowWrapper.js
@@ -23,8 +23,8 @@ class GameFlowWrapper {
         this.game = new Game(details, { router: gameRouter });
         this.game.started = true;
 
-        this.player1 = new PlayerInteractionWrapper(this.game, this.game.getPlayerByName('player1'));
-        this.player2 = new PlayerInteractionWrapper(this.game, this.game.getPlayerByName('player2'));
+        this.player1 = new PlayerInteractionWrapper(this.game, this.game.getPlayerByName('player1'), this);
+        this.player2 = new PlayerInteractionWrapper(this.game, this.game.getPlayerByName('player2'), this);
         this.player1.player.timerSettings.events = false;
         this.player2.player.timerSettings.events = false;
         this.allPlayers = [this.player1, this.player2];

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -321,7 +321,7 @@ var customMatchers = {
                 }
                 let result = {};
 
-                player.clickCard(card);
+                player.clickCardNonChecking(card);
 
                 // this is the default action window prompt (meaning no action was available)
                 result.pass = !player.hasPrompt('Action Window');

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -578,12 +578,18 @@ global.integration = function (definitions) {
                 this.player1.setDeck(options.player1.deck, ['removed from game']);
                 this.player2.setDeck(options.player2.deck, ['removed from game']);
 
-                // add named cards to this for easy reference
+                // add named cards to this for easy reference (allows us to do "this.<cardName>")
+                // note that if cards map to the same property name (i.e., same title), then they won't be added
                 const cardNamesAsProperties = Util.convertNonDuplicateCardNamesToProperties(
                     [this.player1, this.player2],
                     [namedCards1, namedCards2]
                 );
                 cardNamesAsProperties.forEach((card) => this[card.propertyName] = card.cardObj);
+
+                this.p1Base = this.player1.base;
+                this.p1Leader = this.player1.leader;
+                this.p2Base = this.player2.base;
+                this.p2Leader = this.player2.leader;
 
                 // TODO: re-enable when we have tests to do during setup phase
                 // if (options.phase !== 'setup') {

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -4,6 +4,7 @@
 const { select } = require('underscore');
 const { GameMode } = require('../../build/GameMode.js');
 const Contract = require('../../build/game/core/utils/Contract.js');
+const { checkNullCard } = require('./Util.js');
 
 require('./ObjectFormatters.js');
 
@@ -164,6 +165,8 @@ var customMatchers = {
             compare: function (player, card) {
                 if (typeof card === 'string') {
                     card = player.findCardByName(card);
+                } else {
+                    checkNullCard(card);
                 }
                 let result = {};
 
@@ -184,6 +187,7 @@ var customMatchers = {
     toBeAbleToSelectAllOf: function () {
         return {
             compare: function (player, cards) {
+                checkNullCard(cards);
                 if (!Array.isArray(cards)) {
                     cards = [cards];
                 }
@@ -227,6 +231,7 @@ var customMatchers = {
     toBeAbleToSelectNoneOf: function () {
         return {
             compare: function (player, cards) {
+                checkNullCard(cards);
                 if (!Array.isArray(cards)) {
                     cards = [cards];
                 }
@@ -270,6 +275,7 @@ var customMatchers = {
     toBeAbleToSelectExactly: function () {
         return {
             compare: function (player, cards) {
+                checkNullCard(cards);
                 if (!Array.isArray(cards)) {
                     cards = [cards];
                 }
@@ -317,6 +323,7 @@ var customMatchers = {
     toHaveAvailableActionWhenClickedInActionPhaseBy: function () {
         return {
             compare: function (card, player) {
+                checkNullCard(card);
                 if (typeof card === 'string') {
                     card = player.findCardByName(card);
                 }
@@ -377,6 +384,7 @@ var customMatchers = {
     toBeInBottomOfDeck: function () {
         return {
             compare: function (card, player, numCards) {
+                checkNullCard(card);
                 var result = {};
                 const deck = player.deck;
                 const L = deck.length;
@@ -408,6 +416,7 @@ var customMatchers = {
     toAllBeInBottomOfDeck: function () {
         return {
             compare: function (cards, player, numCards) {
+                checkNullCard(cards);
                 var result = {};
                 const deck = player.deck;
                 const L = deck.length;
@@ -584,7 +593,11 @@ global.integration = function (definitions) {
                     [this.player1, this.player2],
                     [namedCards1, namedCards2]
                 );
-                cardNamesAsProperties.forEach((card) => this[card.propertyName] = card.cardObj);
+                this.cardPropertyNames = [];
+                cardNamesAsProperties.forEach((card) => {
+                    this[card.propertyName] = card.cardObj;
+                    this.cardPropertyNames.push(card.propertyName);
+                });
 
                 this.p1Base = this.player1.base;
                 this.p1Leader = this.player1.leader;

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -1,6 +1,8 @@
 const { detectBinary } = require('../../build/Util.js');
 const { GameMode } = require('../../build/GameMode.js');
 
+const { checkNullCard } = require('./Util.js');
+
 class PlayerInteractionWrapper {
     constructor(game, player, testContext) {
         this.game = game;
@@ -474,6 +476,8 @@ class PlayerInteractionWrapper {
     }
 
     clickCard(card, location = 'any', side = 'self', expectChange = true) {
+        checkNullCard(card, this.testContext);
+
         if (typeof card === 'string') {
             card = this.findCardByName(card, location, side);
         }
@@ -513,12 +517,6 @@ class PlayerInteractionWrapper {
         }
 
         return true;
-    }
-
-    clickRing(element) {
-        this.game.ringClicked(this.player.name, element);
-        this.game.continue();
-        // this.checkUnserializableGameState();
     }
 
     clickMenu(card, menuText) {

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -2,9 +2,10 @@ const { detectBinary } = require('../../build/Util.js');
 const { GameMode } = require('../../build/GameMode.js');
 
 class PlayerInteractionWrapper {
-    constructor(game, player) {
+    constructor(game, player, testContext) {
         this.game = game;
         this.player = player;
+        this.testContext = testContext;
 
         player.noTimer = true;
         player.user = {
@@ -308,22 +309,19 @@ class PlayerInteractionWrapper {
         return this.filterCardsByName(name, locations, side)[0];
     }
 
-    findCardsByName(name, locations = 'any', side) {
-        return this.filterCardsByName(name, locations, side);
-    }
-
-    findAllCardsByName(name, locations = 'any', side) {
-        return this.filterCardsByName(name, locations, side);
+    findCardsByName(names, locations = 'any', side) {
+        return this.filterCardsByName(names, locations, side);
     }
 
     /**
      * Filters all of a player's cards using the name and location of a card
-     * @param {String} name - the name of the card
+     * @param {String} names - the names of the cards
      * @param {String[]|String} [locations = 'any'] - locations in which to look for. 'provinces' = 'province 1', 'province 2', etc.
      * @param {?String} side - set to 'opponent' to search in opponent's cards
      */
-    filterCardsByName(name, locations = 'any', side) {
+    filterCardsByName(names, locations = 'any', side) {
         // So that function can accept either lists or single locations
+        const namesAra = Array.isArray(names) ? names : [names];
         if (locations !== 'any') {
             if (!Array.isArray(locations)) {
                 locations = [locations];
@@ -331,11 +329,11 @@ class PlayerInteractionWrapper {
         }
         try {
             var cards = this.filterCards(
-                (card) => card.cardData.internalName === name && (locations === 'any' || locations.includes(card.location)),
+                (card) => namesAra.includes(card.cardData.internalName) && (locations === 'any' || locations.includes(card.location)),
                 side
             );
         } catch (e) {
-            throw new Error(`Name: ${name}, Location: ${locations}. Error thrown: ${e}`);
+            throw new Error(`Names: ${namesAra}, Location: ${locations}. Error thrown: ${e}`);
         }
         return cards;
     }

--- a/test/helpers/Util.js
+++ b/test/helpers/Util.js
@@ -40,6 +40,10 @@ function internalNameToPropertyName(internalName) {
     const titleWords = title.split('-');
 
     let propertyName = titleWords[0];
+    if (propertyName[0] >= '0' && propertyName[0] <= '9') {
+        propertyName = '_' + propertyName;
+    }
+
     for (const word of titleWords.slice(1)) {
         const uppercasedWord = word[0].toUpperCase() + word.slice(1);
         propertyName += uppercasedWord;

--- a/test/helpers/Util.js
+++ b/test/helpers/Util.js
@@ -1,0 +1,50 @@
+function convertNonDuplicateCardNamesToProperties(players, cardNames) {
+    // let cardNames = this.player1.findCardsByName(namedCards1);
+    // cardNames = cardNames.concat(this.player2.findCardsByName(namedCards2));
+
+    let mapToPropertyNamesWithCards = (cardNames, player) => cardNames.map((cardName) => {
+        return {
+            propertyName: internalNameToPropertyName(cardName),
+            cardObj: player.findCardByName(cardName)
+        };
+    });
+
+    let propertyNamesWithCards = mapToPropertyNamesWithCards(cardNames[0], players[0])
+        .concat(mapToPropertyNamesWithCards(cardNames[1], players[1]));
+
+    // remove all instances of any names that are duplicated
+    propertyNamesWithCards.sort((a, b) => {
+        if (a.propertyName === b.propertyName) {
+            return 0;
+        }
+        return a.propertyName > b.propertyName ? 1 : -1;
+    });
+
+    let nonDuplicateCards = [];
+    for (let i = 0; i < propertyNamesWithCards.length; i++) {
+        if (propertyNamesWithCards[i].propertyName === propertyNamesWithCards[i - 1]?.propertyName ||
+            propertyNamesWithCards[i].propertyName === propertyNamesWithCards[i + 1]?.propertyName
+        ) {
+            continue;
+        }
+        nonDuplicateCards.push(propertyNamesWithCards[i]);
+    }
+
+    return nonDuplicateCards;
+}
+
+function internalNameToPropertyName(internalName) {
+    const [title, subtitle] = internalName.split('#');
+
+    const titleWords = title.split('-');
+
+    let propertyName = titleWords[0];
+    for (const word of titleWords.slice(1)) {
+        const uppercasedWord = word[0].toUpperCase() + word.slice(1);
+        propertyName += uppercasedWord;
+    }
+
+    return propertyName;
+}
+
+module.exports = { convertNonDuplicateCardNamesToProperties, internalNameToPropertyName };

--- a/test/helpers/Util.js
+++ b/test/helpers/Util.js
@@ -48,4 +48,27 @@ function internalNameToPropertyName(internalName) {
     return propertyName;
 }
 
-module.exports = { convertNonDuplicateCardNamesToProperties, internalNameToPropertyName };
+// card can be a single or an array
+function checkNullCard(card, testContext) {
+    if (Array.isArray(card)) {
+        if (card.some((cardInList) => cardInList == null)) {
+            throw new Error(`Card list contains one more null elements: ${card.map((cardInList) => getCardName(cardInList)).join(', ')}`);
+        }
+    }
+
+    if (card == null) {
+        throw new Error('Null card value passed to test method');
+    }
+}
+
+function getCardName(card) {
+    if (card == null) {
+        return 'null';
+    }
+    if (typeof card === 'string') {
+        return card;
+    }
+    return card.internalName;
+}
+
+module.exports = { convertNonDuplicateCardNamesToProperties, internalNameToPropertyName, checkNullCard };

--- a/test/helpers/Util.js
+++ b/test/helpers/Util.js
@@ -1,7 +1,8 @@
+/**
+ * helper for generating a list of property names and card objects to add to the test context.
+ * this is so that we can access things as "this.<cardName>"
+ */
 function convertNonDuplicateCardNamesToProperties(players, cardNames) {
-    // let cardNames = this.player1.findCardsByName(namedCards1);
-    // cardNames = cardNames.concat(this.player2.findCardsByName(namedCards2));
-
     let mapToPropertyNamesWithCards = (cardNames, player) => cardNames.map((cardName) => {
         return {
             propertyName: internalNameToPropertyName(cardName),

--- a/test/server/actions/PlayEventFromHand.spec.js
+++ b/test/server/actions/PlayEventFromHand.spec.js
@@ -14,17 +14,6 @@ describe('Play event from hand', function() {
                         spaceArena: ['imperial-interceptor']
                     }
                 });
-
-                this.repair = this.player1.findCardByName('repair');
-                this.daringRaid = this.player1.findCardByName('daring-raid');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-
-                this.wampa = this.player2.findCardByName('wampa');
-                this.interceptor = this.player2.findCardByName('imperial-interceptor');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('it should end up in discard and resources should be exhausted', function () {

--- a/test/server/actions/PlayUnitFromHand.spec.js
+++ b/test/server/actions/PlayUnitFromHand.spec.js
@@ -14,9 +14,6 @@ describe('Play unit from hand', function() {
                         groundArena: ['wampa'],
                     }
                 });
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.firstLegionSnowtrooper = this.player1.findCardByName('first-legion-snowtrooper');
-                this.battlefieldMarine = this.player1.findCardByName('battlefield-marine');
             });
 
             it('it should land in the correct arena exausted and resources should be exhausted', function () {

--- a/test/server/actions/PlayUpgradeFromHand.spec.js
+++ b/test/server/actions/PlayUpgradeFromHand.spec.js
@@ -100,7 +100,6 @@ describe('Play upgrade from hand', function() {
 
             it('its stat bonuses should be correctly applied during combat', function () {
                 this.player1.clickCard(this.tieLn);
-                this.player1.clickCard(this.brightHope);
                 expect(this.brightHope.damage).toBe(5);
                 expect(this.tieLn.damage).toBe(2);
             });
@@ -109,7 +108,6 @@ describe('Play upgrade from hand', function() {
                 this.tieLn.damage = 3;
 
                 this.player1.clickCard(this.tieLn);
-                this.player1.clickCard(this.brightHope);
 
                 expect(this.brightHope.damage).toBe(5);
                 expect(this.tieLn).toBeInLocation('discard');

--- a/test/server/actions/PlayUpgradeFromHand.spec.js
+++ b/test/server/actions/PlayUpgradeFromHand.spec.js
@@ -19,14 +19,14 @@ describe('Play upgrade from hand', function() {
                 this.academyTraining = this.player1.findCardByName('academy-training');
                 this.resilient = this.player1.findCardByName('resilient');
                 this.wampa = this.player1.findCardByName('wampa');
-                this.tieLn = this.player1.findCardByName('tieln-fighter');
+                this.tielnFighter = this.player1.findCardByName('tieln-fighter');
                 this.brightHope = this.player2.findCardByName('bright-hope#the-last-transport');
             });
 
             it('it should be able to be attached to any ground or space unit and apply a stat bonus to it', function () {
                 // upgrade attaches to friendly ground unit
                 this.player1.clickCard(this.entrenched);
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tielnFighter, this.brightHope]);
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.upgrades).toContain(this.entrenched);
                 expect(this.entrenched).toBeInLocation('ground arena');
@@ -39,12 +39,12 @@ describe('Play upgrade from hand', function() {
 
                 // upgrade attaches to friendly space unit
                 this.player1.clickCard(this.academyTraining);
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
-                this.player1.clickCard(this.tieLn);
-                expect(this.tieLn.upgrades).toContain(this.academyTraining);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tielnFighter, this.brightHope]);
+                this.player1.clickCard(this.tielnFighter);
+                expect(this.tielnFighter.upgrades).toContain(this.academyTraining);
                 expect(this.academyTraining).toBeInLocation('space arena');
-                expect(this.tieLn.power).toBe(4);
-                expect(this.tieLn.hp).toBe(3);
+                expect(this.tielnFighter.power).toBe(4);
+                expect(this.tielnFighter.hp).toBe(3);
 
                 expect(this.player1.countExhaustedResources()).toBe(6);
 
@@ -52,7 +52,7 @@ describe('Play upgrade from hand', function() {
 
                 // upgrade attaches to enemy unit
                 this.player1.clickCard(this.resilient);
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tielnFighter, this.brightHope]);
                 this.player1.clickCard(this.brightHope);
                 expect(this.brightHope.upgrades).toContain(this.resilient);
                 expect(this.resilient).toBeInLocation('space arena', this.player2);
@@ -77,19 +77,12 @@ describe('Play upgrade from hand', function() {
                         spaceArena: ['bright-hope#the-last-transport']
                     }
                 });
-
-                this.academyTraining = this.player1.findCardByName('academy-training');
-                this.foundling = this.player1.findCardByName('foundling');
-                this.entrenched = this.player1.findCardByName('entrenched');
-                this.wampa = this.player1.findCardByName('wampa');
-                this.tieLn = this.player1.findCardByName('tieln-fighter');
-                this.brightHope = this.player2.findCardByName('bright-hope#the-last-transport');
             });
 
 
             it('it should stack bonuses with other applied upgrades', function () {
                 this.player1.clickCard(this.foundling);
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tieLn, this.brightHope]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tielnFighter, this.brightHope]);
                 this.player1.clickCard(this.wampa);
 
                 expect(this.wampa.upgrades).toContain(this.academyTraining);
@@ -99,18 +92,18 @@ describe('Play upgrade from hand', function() {
             });
 
             it('its stat bonuses should be correctly applied during combat', function () {
-                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.tielnFighter);
                 expect(this.brightHope.damage).toBe(5);
-                expect(this.tieLn.damage).toBe(2);
+                expect(this.tielnFighter.damage).toBe(2);
             });
 
             it('and the owner is defeated, the upgrade should also be defeated', function () {
-                this.tieLn.damage = 3;
+                this.tielnFighter.damage = 3;
 
-                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.tielnFighter);
 
                 expect(this.brightHope.damage).toBe(5);
-                expect(this.tieLn).toBeInLocation('discard');
+                expect(this.tielnFighter).toBeInLocation('discard');
                 expect(this.entrenched).toBeInLocation('discard');
             });
         });

--- a/test/server/actions/UnitAttack.spec.js
+++ b/test/server/actions/UnitAttack.spec.js
@@ -16,14 +16,6 @@ describe('Basic attack', function() {
                         base: 'jabbas-palace'
                     }
                 });
-
-                this.wampa = this.player1.findCardByName('wampa');
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.atrt = this.player2.findCardByName('frontier-atrt');
-                this.enfysNest = this.player2.findCardByName('enfys-nest#marauder');
-                this.allianceXWing = this.player2.findCardByName('alliance-xwing');
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('the player should only be able to select opponent\'s units in the same arena and base', function () {
@@ -32,28 +24,28 @@ describe('Basic attack', function() {
 
                 // TODO: test helper for managing attacks
                 // can target opponent's ground units and base but not space units
-                expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.enfysNest, this.p2Base]);
+                expect(this.player1).toBeAbleToSelectExactly([this.frontierAtrt, this.enfysNest, this.p2Base]);
             });
 
             it('from space arena to another unit in the space arena, attack should resolve correctly', function () {
                 this.player1.clickCard(this.cartelSpacer);
-                this.player1.clickCard(this.allianceXWing);
+                this.player1.clickCard(this.allianceXwing);
 
                 // attack against base should immediately resolve without prompt for a target, since only one is available
                 expect(this.cartelSpacer.damage).toBe(2);
                 expect(this.cartelSpacer.exhausted).toBe(true);
-                expect(this.allianceXWing.damage).toBe(2);
-                expect(this.allianceXWing.exhausted).toBe(false);
+                expect(this.allianceXwing.damage).toBe(2);
+                expect(this.allianceXwing.exhausted).toBe(false);
             });
 
             it('another unit and neither is defeated, both should receive damage and attacker should be exhausted', function () {
                 this.player1.clickCard(this.wampa);
-                this.player1.clickCard(this.atrt);
+                this.player1.clickCard(this.frontierAtrt);
 
                 expect(this.wampa.damage).toBe(3);
-                expect(this.atrt.damage).toBe(4);
+                expect(this.frontierAtrt.damage).toBe(4);
                 expect(this.wampa.exhausted).toBe(true);
-                expect(this.atrt.exhausted).toBe(false);
+                expect(this.frontierAtrt.exhausted).toBe(false);
             });
 
             it('another unit and both are defeated, both should be in discard', function () {

--- a/test/server/cardImplementations/01_SOR/2-1BSurgicalDroid.spec.js
+++ b/test/server/cardImplementations/01_SOR/2-1BSurgicalDroid.spec.js
@@ -14,73 +14,64 @@ describe('2-1B Surgical Droid', function() {
                         groundArena: [{ card: 'wampa', damage: 2 }]
                     }
                 });
-
-                this.surgicalDroid = this.player1.findCardByName('21b-surgical-droid');
-                this.r2d2 = this.player1.findCardByName('r2d2#ignoring-protocol');
-                this.c3p0 = this.player1.findCardByName('c3po#protocol-droid');
-
-                this.wampa = this.player2.findCardByName('wampa');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('should heal a target with 1 damage to full', function () {
                 // Attack
-                this.player1.clickCard(this.surgicalDroid);
-                expect(this.surgicalDroid).toBeInLocation('ground arena');
+                this.player1.clickCard(this._21bSurgicalDroid);
+                expect(this._21bSurgicalDroid).toBeInLocation('ground arena');
                 expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.wampa]);
                 this.player1.clickCard(this.p2Base);
 
                 // Healing Target
-                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3p0, this.wampa]);
-                this.player1.clickCard(this.c3p0);
+                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3po, this.wampa]);
+                this.player1.clickCard(this.c3po);
 
                 // Confirm Results
-                expect(this.surgicalDroid.exhausted).toBe(true);
-                expect(this.c3p0.damage).toBe(0);
+                expect(this._21bSurgicalDroid.exhausted).toBe(true);
+                expect(this.c3po.damage).toBe(0);
             });
 
             it('should heal 2 damage from a unit', function () {
                 // Attack
-                this.player1.clickCard(this.surgicalDroid);
-                expect(this.surgicalDroid).toBeInLocation('ground arena');
+                this.player1.clickCard(this._21bSurgicalDroid);
+                expect(this._21bSurgicalDroid).toBeInLocation('ground arena');
                 expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.wampa]);
                 this.player1.clickCard(this.p2Base);
 
                 // Healing Target
-                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3p0, this.wampa]);
+                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3po, this.wampa]);
                 this.player1.clickCard(this.r2d2);
 
                 // Confirm Results
-                expect(this.surgicalDroid.exhausted).toBe(true);
+                expect(this._21bSurgicalDroid.exhausted).toBe(true);
                 expect(this.r2d2.damage).toBe(1);
             });
 
             it('should be able to heal an enemy unit', function () {
                 // Attack
-                this.player1.clickCard(this.surgicalDroid);
+                this.player1.clickCard(this._21bSurgicalDroid);
                 expect(this.wampa.damage).toBe(2);
-                expect(this.surgicalDroid).toBeInLocation('ground arena');
+                expect(this._21bSurgicalDroid).toBeInLocation('ground arena');
                 expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.wampa]);
                 this.player1.clickCard(this.p2Base);
 
                 // Healing Target
-                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3p0, this.wampa]);
+                expect(this.player1).toBeAbleToSelectExactly([this.r2d2, this.c3po, this.wampa]);
                 this.player1.clickCard(this.wampa);
 
                 // Confirm Results
-                expect(this.surgicalDroid.exhausted).toBe(true);
+                expect(this._21bSurgicalDroid.exhausted).toBe(true);
                 expect(this.wampa.damage).toBe(0);
             });
 
             it('should be able to be passed', function () {
                 expect(this.r2d2.damage).toBe(3);
-                this.player1.clickCard(this.surgicalDroid);
+                this.player1.clickCard(this._21bSurgicalDroid);
                 this.player1.clickCard(this.p2Base);
 
                 this.player1.clickPrompt('Pass ability');
-                expect(this.surgicalDroid.exhausted).toBe(true);
+                expect(this._21bSurgicalDroid.exhausted).toBe(true);
                 expect(this.r2d2.damage).toBe(3);
             });
         });

--- a/test/server/cardImplementations/01_SOR/AvengerHuntingStarDestroyer.spec.js
+++ b/test/server/cardImplementations/01_SOR/AvengerHuntingStarDestroyer.spec.js
@@ -16,15 +16,7 @@ describe('Avenger, Hunting Star Destroyer', function() {
                 });
 
                 this.p1Avenger = this.player1.findCardByName('avenger#hunting-star-destroyer');
-                this.interceptor = this.player1.findCardByName('imperial-interceptor');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
-
-                this.wampa = this.player2.findCardByName('wampa');
-                this.cartelSpacer = this.player2.findCardByName('cartel-spacer');
                 this.p2Avenger = this.player2.findCardByName('avenger#hunting-star-destroyer');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('forces opponent to defeat friendly non-leader unit when Avenger is played', function () {
@@ -47,7 +39,7 @@ describe('Avenger, Hunting Star Destroyer', function() {
                 this.player2.clickCard(this.p1Base);
 
                 // Player 1 must choose its own unit
-                expect(this.player1).toBeAbleToSelectExactly([this.interceptor, this.pykeSentinel]);
+                expect(this.player1).toBeAbleToSelectExactly([this.imperialInterceptor, this.pykeSentinel]);
                 this.player1.clickCard(this.pykeSentinel);
                 expect(this.pykeSentinel).toBeInLocation('discard');
                 expect(this.p1Base.damage).toBe(8);
@@ -58,17 +50,17 @@ describe('Avenger, Hunting Star Destroyer', function() {
 
                 // Attack with Avenger, choose interceptor as target
                 this.player2.clickCard(this.p2Avenger);
-                this.player2.clickCard(this.interceptor);
+                this.player2.clickCard(this.imperialInterceptor);
 
                 // Interceptor not yet destroyed
-                expect(this.interceptor).toBeInLocation('space arena');
+                expect(this.imperialInterceptor).toBeInLocation('space arena');
 
                 // Player 1 must choose its own unit
-                expect(this.player1).toBeAbleToSelectExactly([this.interceptor, this.pykeSentinel]);
+                expect(this.player1).toBeAbleToSelectExactly([this.imperialInterceptor, this.pykeSentinel]);
 
                 // Choose the defender and check it was destroyed
-                this.player1.clickCard(this.interceptor);
-                expect(this.interceptor).toBeInLocation('discard');
+                this.player1.clickCard(this.imperialInterceptor);
+                expect(this.imperialInterceptor).toBeInLocation('discard');
 
                 // Ensure no damage happened
                 expect(this.p2Avenger.damage).toBe(0);

--- a/test/server/cardImplementations/01_SOR/Confiscate.spec.js
+++ b/test/server/cardImplementations/01_SOR/Confiscate.spec.js
@@ -13,11 +13,6 @@ describe('Confiscate', function() {
                         spaceArena: [{ card: 'imperial-interceptor', upgrades: ['academy-training'] }]
                     }
                 });
-
-                this.confiscate = this.player1.findCardByName('confiscate');
-                this.entrenched = this.player1.findCardByName('entrenched');
-                this.academyTraining = this.player2.findCardByName('academy-training');
-                this.interceptor = this.player2.findCardByName('imperial-interceptor');
             });
 
             it('can defeat an upgrade on a friendly or enemy unit', function () {
@@ -25,7 +20,7 @@ describe('Confiscate', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.entrenched, this.academyTraining]);
 
                 this.player1.clickCard(this.academyTraining);
-                expect(this.interceptor.upgrades.length).toBe(0);
+                expect(this.imperialInterceptor.upgrades.length).toBe(0);
                 expect(this.academyTraining).toBeInLocation('discard');
             });
         });

--- a/test/server/cardImplementations/01_SOR/DeathTrooper.spec.js
+++ b/test/server/cardImplementations/01_SOR/DeathTrooper.spec.js
@@ -14,17 +14,6 @@ describe('Death Trooper', function() {
                         spaceArena: ['imperial-interceptor']
                     }
                 });
-
-                this.deathTrooper = this.player1.findCardByName('death-trooper');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-
-                this.wampa = this.player2.findCardByName('wampa');
-                this.superlaserTech = this.player2.findCardByName('superlaser-technician');
-                this.interceptor = this.player2.findCardByName('imperial-interceptor');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('cannot be passed', function () {
@@ -44,7 +33,7 @@ describe('Death Trooper', function() {
                 this.player1.clickCard(this.deathTrooper);
 
                 // Choose Enemy
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.superlaserTech]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.superlaserTechnician]);
                 this.player1.clickCard(this.wampa);
                 expect(this.deathTrooper.damage).toEqual(2);
                 expect(this.wampa.damage).toEqual(2);

--- a/test/server/cardImplementations/01_SOR/Devotion.spec.js
+++ b/test/server/cardImplementations/01_SOR/Devotion.spec.js
@@ -10,9 +10,6 @@ describe('Devotion', function() {
                     player2: {
                     }
                 });
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('should cause the attached card to heal 2 damage from base on attack', function () {

--- a/test/server/cardImplementations/01_SOR/Devotion.spec.js
+++ b/test/server/cardImplementations/01_SOR/Devotion.spec.js
@@ -11,8 +11,6 @@ describe('Devotion', function() {
                     }
                 });
 
-                this.devotion = this.player1.findCardByName('devotion');
-                this.wampa = this.player1.findCardByName('wampa');
                 this.p1Base = this.player1.base;
                 this.p2Base = this.player2.base;
             });

--- a/test/server/cardImplementations/01_SOR/Entrenched.spec.js
+++ b/test/server/cardImplementations/01_SOR/Entrenched.spec.js
@@ -15,17 +15,17 @@ describe('Entrenched', function() {
 
                 this.entrenched = this.player1.findCardByName('entrenched');
                 this.wampa = this.player1.findCardByName('wampa');
-                this.tieLn = this.player1.findCardByName('tieln-fighter');
+                this.tielnFighter = this.player1.findCardByName('tieln-fighter');
                 this.brightHope = this.player2.findCardByName('bright-hope#the-last-transport');
                 this.p2Base = this.player2.base;
             });
 
             it('should prevent a unit from being able to attack base', function () {
-                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.tielnFighter);
 
                 // attack resolved automatically since there's only one legal target
                 expect(this.brightHope.damage).toBe(5);
-                expect(this.tieLn.damage).toBe(2);
+                expect(this.tielnFighter.damage).toBe(2);
             });
 
             it('should prevent a unit with no opposing arena units from having the option to attack', function () {
@@ -48,19 +48,19 @@ describe('Entrenched', function() {
 
                 this.entrenched = this.player1.findCardByName('entrenched');
                 this.brightHope = this.player1.findCardByName('bright-hope#the-last-transport');
-                this.tieLn = this.player2.findCardByName('tieln-fighter');
+                this.tielnFighter = this.player2.findCardByName('tieln-fighter');
                 this.p2Base = this.player2.base;
             });
 
             it('should work on an opponent\'s unit', function () {
                 // play entrenched on opponent's card
                 this.player1.clickCard(this.entrenched);
-                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.tielnFighter);
 
                 // perform attack, resolves automatically since there's only one legal target
-                this.player2.clickCard(this.tieLn);
+                this.player2.clickCard(this.tielnFighter);
                 expect(this.brightHope.damage).toBe(5);
-                expect(this.tieLn.damage).toBe(2);
+                expect(this.tielnFighter.damage).toBe(2);
             });
         });
     });

--- a/test/server/cardImplementations/01_SOR/Entrenched.spec.js
+++ b/test/server/cardImplementations/01_SOR/Entrenched.spec.js
@@ -12,12 +12,6 @@ describe('Entrenched', function() {
                         spaceArena: ['bright-hope#the-last-transport']
                     }
                 });
-
-                this.entrenched = this.player1.findCardByName('entrenched');
-                this.wampa = this.player1.findCardByName('wampa');
-                this.tielnFighter = this.player1.findCardByName('tieln-fighter');
-                this.brightHope = this.player2.findCardByName('bright-hope#the-last-transport');
-                this.p2Base = this.player2.base;
             });
 
             it('should prevent a unit from being able to attack base', function () {

--- a/test/server/cardImplementations/01_SOR/Experience.spec.js
+++ b/test/server/cardImplementations/01_SOR/Experience.spec.js
@@ -85,15 +85,15 @@ describe('Experience', function() {
                 });
 
                 this.clanWrenRescuer = this.player1.findCardByName('clan-wren-rescuer');
-                this.tieLn = this.player2.findCardByName('tieln-fighter');
+                this.tielnFighter = this.player2.findCardByName('tieln-fighter');
             });
 
             it('its owner and controller should be the player who created it', function () {
                 this.player1.clickCard(this.clanWrenRescuer);
-                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.tielnFighter);
 
-                expect(this.tieLn.upgrades.length).toBe(1);
-                const experience = this.tieLn.upgrades[0];
+                expect(this.tielnFighter.upgrades.length).toBe(1);
+                const experience = this.tielnFighter.upgrades[0];
                 expect(experience.internalName).toBe('experience');
                 expect(experience.owner).toBe(this.player1.player);
                 expect(experience.controller).toBe(this.player1.player);

--- a/test/server/cardImplementations/01_SOR/Experience.spec.js
+++ b/test/server/cardImplementations/01_SOR/Experience.spec.js
@@ -11,20 +11,14 @@ describe('Experience', function() {
                         spaceArena: ['valiant-assault-ship']
                     }
                 });
-
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.experience = this.player1.findCardByName('experience');
-                this.assaultShip = this.player2.findCardByName('valiant-assault-ship');
-
-                this.p2Base = this.player2.base;
             });
 
             it('should grant the attached unit +1/+1 and be removed from game when unit is defeated', function () {
                 this.player1.clickCard(this.cartelSpacer);
-                this.player1.clickCard(this.assaultShip);
+                this.player1.clickCard(this.valiantAssaultShip);
 
                 expect(this.cartelSpacer.damage).toBe(3);
-                expect(this.assaultShip.damage).toBe(3);
+                expect(this.valiantAssaultShip.damage).toBe(3);
 
                 // second attack to confirm that experience effect is still on
                 this.player2.passAction();
@@ -39,9 +33,9 @@ describe('Experience', function() {
                 this.cartelSpacer.exhausted = false;
 
                 this.player1.clickCard(this.cartelSpacer);
-                this.player1.clickCard(this.assaultShip);
+                this.player1.clickCard(this.valiantAssaultShip);
                 expect(this.cartelSpacer).toBeInLocation('discard');
-                expect(this.assaultShip).toBeInLocation('discard');
+                expect(this.valiantAssaultShip).toBeInLocation('discard');
                 expect(this.experience).toBeInLocation('outside the game');
             });
         });

--- a/test/server/cardImplementations/01_SOR/FleetLieutenant.spec.js
+++ b/test/server/cardImplementations/01_SOR/FleetLieutenant.spec.js
@@ -13,15 +13,6 @@ describe('Fleet Lieutenant', function() {
                         spaceArena: ['cartel-spacer']
                     }
                 });
-
-                this.fleetLieutenant = this.player1.findCardByName('fleet-lieutenant');
-                this.wampa = this.player1.findCardByName('wampa');
-                this.monMothma = this.player1.findCardByName('mon-mothma#voice-of-the-rebellion');
-                this.cartelSpacer = this.player2.findCardByName('cartel-spacer');
-                this.peacekeeper = this.player2.findCardByName('sundari-peacekeeper');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('should allowing triggering an attack by a unit when played', function () {
@@ -30,30 +21,30 @@ describe('Fleet Lieutenant', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.monMothma]);
 
                 this.player1.clickCard(this.wampa);
-                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.peacekeeper]);
+                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.sundariPeacekeeper]);
 
-                this.player1.clickCard(this.peacekeeper);
+                this.player1.clickCard(this.sundariPeacekeeper);
                 expect(this.wampa.exhausted).toBe(true);
                 expect(this.wampa.damage).toBe(1);
-                expect(this.peacekeeper.damage).toBe(4);
+                expect(this.sundariPeacekeeper.damage).toBe(4);
             });
 
             it('if used with a rebel unit should give it +2 power', function () {
                 this.player1.clickCard(this.fleetLieutenant);
 
                 this.player1.clickCard(this.monMothma);
-                this.player1.clickCard(this.peacekeeper);
-                expect(this.peacekeeper.damage).toBe(3);
+                this.player1.clickCard(this.sundariPeacekeeper);
+                expect(this.sundariPeacekeeper.damage).toBe(3);
                 expect(this.monMothma.damage).toBe(1);
 
                 // do a second attack to confirm that the +2 bonus has expired
                 this.player2.passAction();
                 this.monMothma.exhausted = false;
                 this.player1.clickCard(this.monMothma);
-                this.player1.clickCard(this.peacekeeper);
+                this.player1.clickCard(this.sundariPeacekeeper);
 
                 expect(this.monMothma.damage).toBe(2);
-                expect(this.peacekeeper.damage).toBe(4);
+                expect(this.sundariPeacekeeper.damage).toBe(4);
             });
 
             it('should allow the user to pass on the attack at the attacker select stage', function () {

--- a/test/server/cardImplementations/01_SOR/GrandMoffTarkinDeathStarOverseer.spec.js
+++ b/test/server/cardImplementations/01_SOR/GrandMoffTarkinDeathStarOverseer.spec.js
@@ -10,27 +10,12 @@ describe('Grand Moff Tarkin, Death Star Overseer', function() {
                     },
                     player2: {
                         hand: ['grand-moff-tarkin#death-star-overseer'],
-                        deck: ['system-patrol-craft', 'clan-wren-rescuer', 'village-protectors', 'concord-dawn-interceptors', 'gentle-giant', 'wampa', 'cargo-juggernaut', 'public-enemy']
+                        deck: ['system-patrol-craft', 'clan-wren-rescuer', 'village-protectors', 'concord-dawn-interceptors', 'gentle-giant', 'frontier-atrt', 'cargo-juggernaut', 'public-enemy']
                     }
                 });
 
                 this.p1Tarkin = this.player1.findCardByName('grand-moff-tarkin#death-star-overseer');
-
-                this.academyDefenseWalker = this.player1.findCardByName('academy-defense-walker');
-                this.cellBlockGuard = this.player1.findCardByName('cell-block-guard');
-                this.scoutBikePursuer = this.player1.findCardByName('scout-bike-pursuer');
-
-                this.battlefieldMarine = this.player1.findCardByName('battlefield-marine');
-                this.wampa = this.player1.findCardByName('wampa');
-
-                this.allianceDispatcher = this.player1.findCardByName('alliance-dispatcher');
-
                 this.p2tarkin = this.player2.findCardByName('grand-moff-tarkin#death-star-overseer');
-                this.clanWrenRescuer = this.player2.findCardByName('clan-wren-rescuer');
-                this.concordDawnInterceptors = this.player2.findCardByName('concord-dawn-interceptors');
-                this.gentleGiant = this.player2.findCardByName('gentle-giant');
-                this.systemPatrolCraft = this.player2.findCardByName('system-patrol-craft');
-                this.villageProtectors = this.player2.findCardByName('village-protectors');
             });
 
             it('should prompt to choose up to 2 Imperials from the top 5 cards, reveal chosen, draw them, and put the rest on the bottom of the deck', function () {

--- a/test/server/cardImplementations/01_SOR/MomentOfPeace.spec.js
+++ b/test/server/cardImplementations/01_SOR/MomentOfPeace.spec.js
@@ -12,10 +12,6 @@ describe('Moment of Peace', function() {
                         spaceArena: [{ card: 'cartel-spacer', upgrades: ['shield'] }]
                     }
                 });
-
-                this.momentOfPeace = this.player1.findCardByName('moment-of-peace');
-                this.wampa = this.player1.findCardByName('wampa');
-                this.cartelSpacer = this.player2.findCardByName('cartel-spacer');
             });
 
             it('can give a shield to a unit', function () {

--- a/test/server/cardImplementations/01_SOR/MonMothmaVoiceoftheRebellion.spec.js
+++ b/test/server/cardImplementations/01_SOR/MonMothmaVoiceoftheRebellion.spec.js
@@ -9,14 +9,6 @@ describe('Mon Mothma, Voice of the Rebellion', function() {
                         deck: ['cell-block-guard', 'pyke-sentinel', 'volunteer-soldier', 'cartel-spacer', 'battlefield-marine', 'wampa', 'viper-probe-droid', 'snowtrooper-lieutenant'],
                     }
                 });
-
-                this.monMothma = this.player1.findCardByName('mon-mothma#voice-of-the-rebellion');
-                this.battlefieldMarine = this.player1.findCardByName('battlefield-marine');
-
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.cellBlockGuard = this.player1.findCardByName('cell-block-guard');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
-                this.volunteerSoldier = this.player1.findCardByName('volunteer-soldier');
             });
 
             it('should prompt to choose a Rebel from the top 5 cards, reveal it, draw it, and move the rest to the bottom of the deck', function () {

--- a/test/server/cardImplementations/01_SOR/Repair.spec.js
+++ b/test/server/cardImplementations/01_SOR/Repair.spec.js
@@ -14,22 +14,12 @@ describe('Repair', function() {
                         spaceArena: ['imperial-interceptor']
                     }
                 });
-
-                this.repair = this.player1.findCardByName('repair');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-
-                this.wampa = this.player2.findCardByName('wampa');
-                this.interceptor = this.player2.findCardByName('imperial-interceptor');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('can heal a unit', function () {
                 this.wampa.damage = 3;
                 this.player1.clickCard(this.repair);
-                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.interceptor, this.p2Base]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.imperialInterceptor, this.p2Base]);
 
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.damage).toBe(0);
@@ -39,7 +29,7 @@ describe('Repair', function() {
                 this.p1Base.damage = 3;
 
                 this.player1.clickCard(this.repair);
-                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.interceptor, this.p2Base]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.imperialInterceptor, this.p2Base]);
 
                 this.player1.clickCard(this.p1Base);
                 expect(this.p1Base.damage).toBe(0);
@@ -47,7 +37,7 @@ describe('Repair', function() {
 
             it('can select a target with no damage', function () {
                 this.player1.clickCard(this.repair);
-                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.interceptor, this.p2Base]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.imperialInterceptor, this.p2Base]);
 
                 this.player1.clickCard(this.p1Base);
                 expect(this.p1Base.damage).toBe(0);
@@ -57,7 +47,7 @@ describe('Repair', function() {
                 this.p1Base.damage = 2;
 
                 this.player1.clickCard(this.repair);
-                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.interceptor, this.p2Base]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.imperialInterceptor, this.p2Base]);
 
                 this.player1.clickCard(this.p1Base);
                 expect(this.p1Base.damage).toBe(0);

--- a/test/server/cardImplementations/01_SOR/SabineWrenExplosivesArtist.spec.js
+++ b/test/server/cardImplementations/01_SOR/SabineWrenExplosivesArtist.spec.js
@@ -13,13 +13,6 @@ describe('Sabine Wren, Explosives Artist', function() {
                     }
                 });
 
-                this.sabine = this.player1.findCardByName('sabine-wren#explosives-artist');
-                this.marine = this.player1.findCardByName('battlefield-marine');
-                this.wampa = this.player2.findCardByName('wampa');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
-
                 // sabine is only partially implemented, still need to handle:
                 // - the effect override if she gains sentinel
                 // - her active ability
@@ -29,7 +22,7 @@ describe('Sabine Wren, Explosives Artist', function() {
                 this.player2.setActivePlayer();
                 this.player2.clickCard(this.wampa);
 
-                expect(this.player2).toBeAbleToSelectExactly([this.marine, this.p1Base]);
+                expect(this.player2).toBeAbleToSelectExactly([this.battlefieldMarine, this.p1Base]);
             });
 
             it('should be targetable when less than 3 friendly aspects are in play', function () {
@@ -37,7 +30,7 @@ describe('Sabine Wren, Explosives Artist', function() {
                 this.player2.setActivePlayer();
                 this.player2.clickCard(this.wampa);
 
-                expect(this.player2).toBeAbleToSelectExactly([this.marine, this.p1Base, this.sabine]);
+                expect(this.player2).toBeAbleToSelectExactly([this.battlefieldMarine, this.p1Base, this.sabineWren]);
             });
         });
     });

--- a/test/server/cardImplementations/01_SOR/SearchYourFeelings.spec.js
+++ b/test/server/cardImplementations/01_SOR/SearchYourFeelings.spec.js
@@ -9,17 +9,6 @@ describe('Search Your Feelings', function() {
                         deck: ['battlefield-marine', 'cartel-spacer', 'cell-block-guard', 'pyke-sentinel', 'volunteer-soldier']
                     }
                 });
-
-                this.searchYourFeelings = this.player1.findCardByName('search-your-feelings');
-
-                this.battlefieldMarine = this.player1.findCardByName('battlefield-marine');
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.cellBlockGuard = this.player1.findCardByName('cell-block-guard');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
-                this.volunteerSoldier = this.player1.findCardByName('volunteer-soldier');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('should be able to retrieve ANY card from the deck', function () {

--- a/test/server/cardImplementations/01_SOR/Shield.spec.js
+++ b/test/server/cardImplementations/01_SOR/Shield.spec.js
@@ -15,32 +15,32 @@ describe('Shield', function() {
 
                 this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
                 this.vanquish = this.player1.findCardByName('vanquish');
-                this.tieLn = this.player2.findCardByName('tieln-fighter');
+                this.tielnFighter = this.player2.findCardByName('tieln-fighter');
                 this.shield = this.player2.findCardByName('shield');
             });
 
             it('should defeat itself to prevent damage to the attached unit', function () {
                 this.player1.clickCard(this.cartelSpacer);
-                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.tielnFighter);
 
                 expect(this.cartelSpacer.damage).toBe(2);
-                expect(this.tieLn.damage).toBe(0);
+                expect(this.tielnFighter.damage).toBe(0);
 
                 expect(this.shield).toBeInLocation('outside the game');
-                expect(this.tieLn.upgrades.length).toBe(0);
+                expect(this.tielnFighter.upgrades.length).toBe(0);
 
                 // second attack to confirm that shield effect is off
-                this.player2.clickCard(this.tieLn);
+                this.player2.clickCard(this.tielnFighter);
                 this.player2.clickCard(this.cartelSpacer);
                 expect(this.cartelSpacer).toBeInLocation('discard');
-                expect(this.tieLn).toBeInLocation('discard');
+                expect(this.tielnFighter).toBeInLocation('discard');
             });
 
             it('should be removed from the game when the attached unit is defeated', function () {
                 this.player1.clickCard(this.vanquish);
-                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.tielnFighter);
 
-                expect(this.tieLn).toBeInLocation('discard');
+                expect(this.tielnFighter).toBeInLocation('discard');
                 expect(this.shield).toBeInLocation('outside the game');
             });
         });
@@ -58,7 +58,7 @@ describe('Shield', function() {
                 });
 
                 this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.tieLn = this.player2.findCardByName('tieln-fighter');
+                this.tielnFighter = this.player2.findCardByName('tieln-fighter');
                 this.shields = this.player2.findCardsByName('shield');
             });
 
@@ -66,20 +66,20 @@ describe('Shield', function() {
                 const getShieldLocationsSorted = (shields) => shields.map((shield) => shield.location).sort();
 
                 this.player1.clickCard(this.cartelSpacer);
-                this.player1.clickCard(this.tieLn);
+                this.player1.clickCard(this.tielnFighter);
 
                 expect(this.cartelSpacer.damage).toBe(2);
-                expect(this.tieLn.damage).toBe(0);
-                expect(this.tieLn.upgrades.length).toBe(1);
+                expect(this.tielnFighter.damage).toBe(0);
+                expect(this.tielnFighter.upgrades.length).toBe(1);
 
                 expect(getShieldLocationsSorted(this.shields)).toEqual(['outside the game', 'space arena']);
 
                 // second attack
-                this.player2.clickCard(this.tieLn);
+                this.player2.clickCard(this.tielnFighter);
                 this.player2.clickCard(this.cartelSpacer);
                 expect(this.cartelSpacer).toBeInLocation('discard');
-                expect(this.tieLn.damage).toBe(0);
-                expect(this.tieLn.upgrades.length).toBe(0);
+                expect(this.tielnFighter.damage).toBe(0);
+                expect(this.tielnFighter.upgrades.length).toBe(0);
 
                 expect(getShieldLocationsSorted(this.shields)).toEqual(['outside the game', 'outside the game']);
             });
@@ -98,14 +98,14 @@ describe('Shield', function() {
                 });
 
                 this.momentOfPeace = this.player1.findCardByName('moment-of-peace');
-                this.tieLn = this.player2.findCardByName('tieln-fighter');
+                this.tielnFighter = this.player2.findCardByName('tieln-fighter');
             });
 
             it('its owner and controller should be the player who created it', function () {
                 this.player1.clickCard(this.momentOfPeace);
 
-                expect(this.tieLn.upgrades.length).toBe(1);
-                const shield = this.tieLn.upgrades[0];
+                expect(this.tielnFighter.upgrades.length).toBe(1);
+                const shield = this.tielnFighter.upgrades[0];
                 expect(shield.internalName).toBe('shield');
                 expect(shield.owner).toBe(this.player1.player);
                 expect(shield.controller).toBe(this.player1.player);

--- a/test/server/cardImplementations/01_SOR/Shield.spec.js
+++ b/test/server/cardImplementations/01_SOR/Shield.spec.js
@@ -12,11 +12,6 @@ describe('Shield', function() {
                         spaceArena: [{ card: 'tieln-fighter', upgrades: ['shield'] }]
                     }
                 });
-
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.vanquish = this.player1.findCardByName('vanquish');
-                this.tielnFighter = this.player2.findCardByName('tieln-fighter');
-                this.shield = this.player2.findCardByName('shield');
             });
 
             it('should defeat itself to prevent damage to the attached unit', function () {
@@ -57,8 +52,6 @@ describe('Shield', function() {
                     }
                 });
 
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.tielnFighter = this.player2.findCardByName('tieln-fighter');
                 this.shields = this.player2.findCardsByName('shield');
             });
 

--- a/test/server/cardImplementations/01_SOR/SnowtrooperLieutenant.spec.js
+++ b/test/server/cardImplementations/01_SOR/SnowtrooperLieutenant.spec.js
@@ -13,47 +13,38 @@ describe('Snowtrooper Lieutenant', function() {
                         spaceArena: ['cartel-spacer']
                     }
                 });
-
-                this.snowtrooperLieutenant = this.player1.findCardByName('snowtrooper-lieutenant');
-                this.wampa = this.player1.findCardByName('wampa');
-                this.piett = this.player1.findCardByName('admiral-piett#captain-of-the-executor');
-                this.cartelSpacer = this.player2.findCardByName('cartel-spacer');
-                this.peacekeeper = this.player2.findCardByName('sundari-peacekeeper');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('should allowing triggering an attack by a unit when played', function () {
                 this.player1.clickCard(this.snowtrooperLieutenant);
                 expect(this.snowtrooperLieutenant).toBeInLocation('ground arena');
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.piett]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.admiralPiett]);
 
                 this.player1.clickCard(this.wampa);
-                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.peacekeeper]);
+                expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.sundariPeacekeeper]);
 
-                this.player1.clickCard(this.peacekeeper);
+                this.player1.clickCard(this.sundariPeacekeeper);
                 expect(this.wampa.exhausted).toBe(true);
                 expect(this.wampa.damage).toBe(1);
-                expect(this.peacekeeper.damage).toBe(4);
+                expect(this.sundariPeacekeeper.damage).toBe(4);
             });
 
             it('if used with an imperial unit should give it +2 power', function () {
                 this.player1.clickCard(this.snowtrooperLieutenant);
 
-                this.player1.clickCard(this.piett);
-                this.player1.clickCard(this.peacekeeper);
-                expect(this.peacekeeper.damage).toBe(3);
-                expect(this.piett.damage).toBe(1);
+                this.player1.clickCard(this.admiralPiett);
+                this.player1.clickCard(this.sundariPeacekeeper);
+                expect(this.sundariPeacekeeper.damage).toBe(3);
+                expect(this.admiralPiett.damage).toBe(1);
 
                 // do a second attack to confirm that the +2 bonus has expired
                 this.player2.passAction();
-                this.piett.exhausted = false;
-                this.player1.clickCard(this.piett);
-                this.player1.clickCard(this.peacekeeper);
+                this.admiralPiett.exhausted = false;
+                this.player1.clickCard(this.admiralPiett);
+                this.player1.clickCard(this.sundariPeacekeeper);
 
-                expect(this.piett.damage).toBe(2);
-                expect(this.peacekeeper.damage).toBe(4);
+                expect(this.admiralPiett.damage).toBe(2);
+                expect(this.sundariPeacekeeper.damage).toBe(4);
             });
         });
     });

--- a/test/server/cardImplementations/01_SOR/Tarkintown.spec.js
+++ b/test/server/cardImplementations/01_SOR/Tarkintown.spec.js
@@ -28,7 +28,6 @@ describe('Tarkintown', function() {
 
                 // confirm that the ability cannot be used again
                 this.player2.passAction();
-                this.player1.clickCard(this.tarkintown);
                 expect(this.tarkintown).not.toHaveAvailableActionWhenClickedInActionPhaseBy(this.player1);
 
                 // skip to next turn so we can confirm that the ability is still unusable

--- a/test/server/cardImplementations/01_SOR/Tarkintown.spec.js
+++ b/test/server/cardImplementations/01_SOR/Tarkintown.spec.js
@@ -16,14 +16,14 @@ describe('Tarkintown', function() {
                 });
 
                 this.tarkintown = this.player1.base;
-                this.atrt = this.player2.findCardByName('frontier-atrt');
+                this.frontierAtrt = this.player2.findCardByName('frontier-atrt');
             });
 
             it('should deal 3 damage to a damaged enemy unit', function () {
                 this.player1.clickCard(this.tarkintown);
 
                 // should resolve automatically since there's only one target
-                expect(this.atrt.damage).toBe(4);
+                expect(this.frontierAtrt.damage).toBe(4);
                 expect(this.tarkintown.epicActionSpent).toBe(true);
 
                 // confirm that the ability cannot be used again

--- a/test/server/cardImplementations/01_SOR/Tarkintown.spec.js
+++ b/test/server/cardImplementations/01_SOR/Tarkintown.spec.js
@@ -14,9 +14,6 @@ describe('Tarkintown', function() {
                         ],
                     }
                 });
-
-                this.tarkintown = this.player1.base;
-                this.frontierAtrt = this.player2.findCardByName('frontier-atrt');
             });
 
             it('should deal 3 damage to a damaged enemy unit', function () {

--- a/test/server/cardImplementations/01_SOR/TieAdvanced.spec.js
+++ b/test/server/cardImplementations/01_SOR/TieAdvanced.spec.js
@@ -12,10 +12,6 @@ describe('Tie Avanced', function() {
                         spaceArena: ['cartel-spacer']
                     }
                 });
-
-                this.tieAdvanced = this.player1.findCardByName('tie-advanced');
-                this.atst = this.player1.findCardByName('atst');
-                this.tielnFighter = this.player1.findCardByName('tieln-fighter');
             });
 
             it('can give two experience to a unit', function () {

--- a/test/server/cardImplementations/01_SOR/TieAdvanced.spec.js
+++ b/test/server/cardImplementations/01_SOR/TieAdvanced.spec.js
@@ -15,12 +15,12 @@ describe('Tie Avanced', function() {
 
                 this.tieAdvanced = this.player1.findCardByName('tie-advanced');
                 this.atst = this.player1.findCardByName('atst');
-                this.tieLn = this.player1.findCardByName('tieln-fighter');
+                this.tielnFighter = this.player1.findCardByName('tieln-fighter');
             });
 
             it('can give two experience to a unit', function () {
                 this.player1.clickCard(this.tieAdvanced);
-                expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tieLn]);
+                expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tielnFighter]);
                 this.player1.clickCard(this.atst);
 
                 expect(this.atst.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience']);
@@ -28,10 +28,10 @@ describe('Tie Avanced', function() {
 
             it('can give two experience to a unit that already has an experience', function () {
                 this.player1.clickCard(this.tieAdvanced);
-                expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tieLn]);
-                this.player1.clickCard(this.tieLn);
+                expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tielnFighter]);
+                this.player1.clickCard(this.tielnFighter);
 
-                expect(this.tieLn.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience', 'experience']);
+                expect(this.tielnFighter.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience', 'experience']);
             });
         });
     });

--- a/test/server/cardImplementations/01_SOR/Vanquish.spec.js
+++ b/test/server/cardImplementations/01_SOR/Vanquish.spec.js
@@ -13,20 +13,15 @@ describe('Vanquish', function() {
                         spaceArena: ['imperial-interceptor']
                     }
                 });
-
-                this.vanquish = this.player1.findCardByName('vanquish');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
-                this.wampa = this.player2.findCardByName('wampa');
-                this.interceptor = this.player2.findCardByName('imperial-interceptor');
             });
 
             // TODO LEADERS: add a leader unit to confirm it can't be targeted
             it('should defeat any non-leader unit', function () {
                 this.player1.clickCard(this.vanquish);
-                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.wampa, this.interceptor]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.wampa, this.imperialInterceptor]);
 
-                this.player1.clickCard(this.interceptor);
-                expect(this.interceptor).toBeInLocation('discard');
+                this.player1.clickCard(this.imperialInterceptor);
+                expect(this.imperialInterceptor).toBeInLocation('discard');
             });
         });
     });

--- a/test/server/cardImplementations/02_SHD/ClanWrenRescuer.spec.js
+++ b/test/server/cardImplementations/02_SHD/ClanWrenRescuer.spec.js
@@ -12,10 +12,6 @@ describe('Clan Wren Rescuer', function() {
                         spaceArena: ['cartel-spacer']
                     }
                 });
-
-                this.clanWrenRescuer = this.player1.findCardByName('clan-wren-rescuer');
-                this.wampa = this.player1.findCardByName('wampa');
-                this.cartelSpacer = this.player2.findCardByName('cartel-spacer');
             });
 
             it('should give an experience token to a unit', function () {

--- a/test/server/cardImplementations/02_SHD/DaringRaid.spec.js
+++ b/test/server/cardImplementations/02_SHD/DaringRaid.spec.js
@@ -20,7 +20,7 @@ describe('Daring Raid', function() {
                 this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
 
                 this.wampa = this.player2.findCardByName('wampa');
-                this.interceptor = this.player2.findCardByName('imperial-interceptor');
+                this.imperialInterceptor = this.player2.findCardByName('imperial-interceptor');
 
                 this.p1Base = this.player1.base;
                 this.p2Base = this.player2.base;
@@ -28,7 +28,7 @@ describe('Daring Raid', function() {
 
             it('can deal damage to a unit', function () {
                 this.player1.clickCard(this.daringRaid);
-                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.interceptor, this.p2Base]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.imperialInterceptor, this.p2Base]);
 
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.damage).toBe(2);
@@ -36,7 +36,7 @@ describe('Daring Raid', function() {
 
             it('can deal damage to a base', function () {
                 this.player1.clickCard(this.daringRaid);
-                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.interceptor, this.p2Base]);
+                expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.cartelSpacer, this.p1Base, this.wampa, this.imperialInterceptor, this.p2Base]);
 
                 this.player1.clickCard(this.p1Base);
                 expect(this.p1Base.damage).toBe(2);

--- a/test/server/cardImplementations/02_SHD/DaringRaid.spec.js
+++ b/test/server/cardImplementations/02_SHD/DaringRaid.spec.js
@@ -14,16 +14,6 @@ describe('Daring Raid', function() {
                         spaceArena: ['imperial-interceptor']
                     }
                 });
-
-                this.daringRaid = this.player1.findCardByName('daring-raid');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-
-                this.wampa = this.player2.findCardByName('wampa');
-                this.imperialInterceptor = this.player2.findCardByName('imperial-interceptor');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('can deal damage to a unit', function () {

--- a/test/server/cardImplementations/02_SHD/GreefKargaAffableCommissioner.spec.js
+++ b/test/server/cardImplementations/02_SHD/GreefKargaAffableCommissioner.spec.js
@@ -9,14 +9,6 @@ describe('Greef Karga, Affable Commissioner', function() {
                         deck: ['foundling', 'pyke-sentinel', 'atst', 'cartel-spacer', 'battlefield-marine']
                     }
                 });
-
-                this.greefKarga = this.player1.findCardByName('greef-karga#affable-commissioner');
-
-                this.atst = this.player1.findCardByName('atst');
-                this.battlefieldMarine = this.player1.findCardByName('battlefield-marine');
-                this.cartelSpacer = this.player1.findCardByName('cartel-spacer');
-                this.foundling = this.player1.findCardByName('foundling');
-                this.pykeSentinel = this.player1.findCardByName('pyke-sentinel');
             });
 
             it('can draw upgrade', function () {

--- a/test/server/cardImplementations/02_SHD/GroguIrresistible.spec.js
+++ b/test/server/cardImplementations/02_SHD/GroguIrresistible.spec.js
@@ -14,14 +14,6 @@ describe('Grogu, Irresistible', function() {
                         ],
                     }
                 });
-
-                this.grogu = this.player1.findCardByName('grogu#irresistible');
-                this.wampa = this.player1.findCardByName('wampa');
-                this.frontierAtrt = this.player2.findCardByName('frontier-atrt');
-                this.enfysNest = this.player2.findCardByName('enfys-nest#marauder');
-
-                this.p1Base = this.player1.base;
-                this.p2Base = this.player2.base;
             });
 
             it('should exhaust a selected enemy unit', function () {

--- a/test/server/cardImplementations/02_SHD/GroguIrresistible.spec.js
+++ b/test/server/cardImplementations/02_SHD/GroguIrresistible.spec.js
@@ -17,7 +17,7 @@ describe('Grogu, Irresistible', function() {
 
                 this.grogu = this.player1.findCardByName('grogu#irresistible');
                 this.wampa = this.player1.findCardByName('wampa');
-                this.atrt = this.player2.findCardByName('frontier-atrt');
+                this.frontierAtrt = this.player2.findCardByName('frontier-atrt');
                 this.enfysNest = this.player2.findCardByName('enfys-nest#marauder');
 
                 this.p1Base = this.player1.base;
@@ -29,7 +29,7 @@ describe('Grogu, Irresistible', function() {
                 this.player1.clickPrompt('Exhaust an enemy unit');
 
                 // can target opponent's units only
-                expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.enfysNest]);
+                expect(this.player1).toBeAbleToSelectExactly([this.frontierAtrt, this.enfysNest]);
 
                 this.player1.clickCard(this.enfysNest);
                 expect(this.grogu.exhausted).toBe(true);

--- a/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
+++ b/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
@@ -45,7 +45,7 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
 
                 this.crumb = this.player1.findCardByName('salacious-crumb#obnoxious-pet');
                 this.wampa = this.player1.findCardByName('wampa');
-                this.atrt = this.player2.findCardByName('frontier-atrt');
+                this.frontierAtrt = this.player2.findCardByName('frontier-atrt');
                 this.cartelSpacer = this.player2.findCardByName('cartel-spacer');
             });
 
@@ -54,10 +54,10 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
                 this.player1.clickPrompt('Deal 1 damage to a ground unit');
 
                 // can target any ground unit
-                expect(this.player1).toBeAbleToSelectExactly([this.atrt, this.wampa]);
+                expect(this.player1).toBeAbleToSelectExactly([this.frontierAtrt, this.wampa]);
 
-                this.player1.clickCard(this.atrt);
-                expect(this.atrt.damage).toBe(1);
+                this.player1.clickCard(this.frontierAtrt);
+                expect(this.frontierAtrt.damage).toBe(1);
                 expect(this.crumb).toBeInLocation('hand');
             });
 

--- a/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
+++ b/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
@@ -9,22 +9,22 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
                     }
                 });
 
-                this.crumb = this.player1.findCardByName('salacious-crumb#obnoxious-pet');
+                this.salaciousCrumb = this.player1.findCardByName('salacious-crumb#obnoxious-pet');
                 this.p1Base = this.player1.base;
             });
 
             it('should heal 1 from friendly base', function () {
                 this.p1Base.damage = 5;
-                this.player1.clickCard(this.crumb);
-                expect(this.crumb).toBeInLocation('ground arena');
+                this.player1.clickCard(this.salaciousCrumb);
+                expect(this.salaciousCrumb).toBeInLocation('ground arena');
 
                 expect(this.p1Base.damage).toBe(4);
             });
 
             it('should heal 0 from base if base has no damage', function () {
                 this.p1Base.damage = 0;
-                this.player1.clickCard(this.crumb);
-                expect(this.crumb).toBeInLocation('ground arena');
+                this.player1.clickCard(this.salaciousCrumb);
+                expect(this.salaciousCrumb).toBeInLocation('ground arena');
 
                 expect(this.p1Base.damage).toBe(0);
             });
@@ -42,15 +42,10 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
                         spaceArena: ['cartel-spacer']
                     }
                 });
-
-                this.crumb = this.player1.findCardByName('salacious-crumb#obnoxious-pet');
-                this.wampa = this.player1.findCardByName('wampa');
-                this.frontierAtrt = this.player2.findCardByName('frontier-atrt');
-                this.cartelSpacer = this.player2.findCardByName('cartel-spacer');
             });
 
             it('should deal 1 damage to any selected ground unit', function () {
-                this.player1.clickCard(this.crumb);
+                this.player1.clickCard(this.salaciousCrumb);
                 this.player1.clickPrompt('Deal 1 damage to a ground unit');
 
                 // can target any ground unit
@@ -58,12 +53,12 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
 
                 this.player1.clickCard(this.frontierAtrt);
                 expect(this.frontierAtrt.damage).toBe(1);
-                expect(this.crumb).toBeInLocation('hand');
+                expect(this.salaciousCrumb).toBeInLocation('hand');
             });
 
             it('should not be available if Crumb is exhausted', function () {
-                this.crumb.exhausted = true;
-                expect(this.crumb).not.toHaveAvailableActionWhenClickedInActionPhaseBy(this.player1);
+                this.salaciousCrumb.exhausted = true;
+                expect(this.salaciousCrumb).not.toHaveAvailableActionWhenClickedInActionPhaseBy(this.player1);
             });
         });
     });

--- a/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
+++ b/test/server/cardImplementations/02_SHD/SalaciousCrumbObnoxiousPet.spec.js
@@ -8,9 +8,6 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
                         hand: ['salacious-crumb#obnoxious-pet']
                     }
                 });
-
-                this.salaciousCrumb = this.player1.findCardByName('salacious-crumb#obnoxious-pet');
-                this.p1Base = this.player1.base;
             });
 
             it('should heal 1 from friendly base', function () {

--- a/test/server/cardImplementations/02_SHD/VambraceGrappleshot.spec.js
+++ b/test/server/cardImplementations/02_SHD/VambraceGrappleshot.spec.js
@@ -11,10 +11,6 @@ describe('Vambrace Grappleshot', function() {
                         groundArena: ['snowspeeder']
                     }
                 });
-
-                this.vambraceGrappleshot = this.player1.findCardByName('vambrace-grappleshot');
-                this.battlefieldMarine = this.player1.findCardByName('battlefield-marine');
-                this.snowspeeder = this.player2.findCardByName('snowspeeder');
             });
 
             it('should exhaust the defender on attack', function () {

--- a/test/server/cardImplementations/02_SHD/VambraceGrappleshot.spec.js
+++ b/test/server/cardImplementations/02_SHD/VambraceGrappleshot.spec.js
@@ -13,16 +13,16 @@ describe('Vambrace Grappleshot', function() {
                 });
 
                 this.vambraceGrappleshot = this.player1.findCardByName('vambrace-grappleshot');
-                this.marine = this.player1.findCardByName('battlefield-marine');
+                this.battlefieldMarine = this.player1.findCardByName('battlefield-marine');
                 this.snowspeeder = this.player2.findCardByName('snowspeeder');
             });
 
             it('should exhaust the defender on attack', function () {
-                this.player1.clickCard(this.marine);
+                this.player1.clickCard(this.battlefieldMarine);
                 this.player1.clickCard(this.snowspeeder);
 
                 expect(this.snowspeeder.damage).toBe(5);
-                expect(this.marine.damage).toBe(3);
+                expect(this.battlefieldMarine.damage).toBe(3);
                 expect(this.snowspeeder.exhausted).toBe(true);
             });
 
@@ -30,11 +30,11 @@ describe('Vambrace Grappleshot', function() {
                 this.vambraceGrappleshot.unattach();
                 this.player1.moveCard(this.vambraceGrappleshot, 'discard');
 
-                this.player1.clickCard(this.marine);
+                this.player1.clickCard(this.battlefieldMarine);
                 this.player1.clickCard(this.snowspeeder);
 
                 expect(this.snowspeeder.damage).toBe(3);
-                expect(this.marine).toBeInLocation('discard');
+                expect(this.battlefieldMarine).toBeInLocation('discard');
                 expect(this.snowspeeder.exhausted).toBe(false);
             });
         });
@@ -52,13 +52,13 @@ describe('Vambrace Grappleshot', function() {
                 });
 
                 this.vambraceGrappleshot = this.player1.findCardByName('vambrace-grappleshot');
-                this.marine = this.player1.findCardByName('battlefield-marine');
+                this.battlefieldMarine = this.player1.findCardByName('battlefield-marine');
                 this.snowspeeder = this.player1.findCardByName('snowspeeder');
             });
 
             it('should not be playable on vehicles', function () {
                 this.player1.clickCard(this.vambraceGrappleshot);
-                expect(this.marine.upgrades).toContain(this.vambraceGrappleshot);
+                expect(this.battlefieldMarine.upgrades).toContain(this.vambraceGrappleshot);
             });
         });
     });


### PR DESCRIPTION
Added a couple of things to make writing tests simpler and less frustrating:

- Added a check for `clickCard` that will throw an error if clicking the card did not change the player's prompt state at all (i.e., if clicking the card had no effect). Also added a version of the method that skips this check for special cases.
- Automated the addition of any named cards to the `this` test object so that we don't need a large, cumbersome, error-prone block of searching cards by name for every test