### PR TITLE
Add state watchers and a few example cards

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -30,7 +30,7 @@ jobs:
           uses: actions/cache@v3
           with:
             path: ./test/json
-            key: sor-shd-manual-v02-types
+            key: sor-shd-manual-v03-types
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards
 

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -24,7 +24,7 @@ jobs:
           uses: actions/cache@v3
           with:
             path: ./test/json
-            key: sor-shd-manual-v02-types
+            key: sor-shd-manual-v03-specialchars
 
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Forceteki
 Proof-of-concept for web based implementation of Star Wars Unlimited TCG. Very WIP.
 
+## Contributing
+For details on how to get started adding cards, see the [contributor's guide](./docs/implementing-cards.md).
+
 ## Development Quickstart
 Follow these instructions to get to the point of being able to run the [unit tests](./test/server/) locally.
 
@@ -32,6 +35,7 @@ npm test
 
 # run a specific test file only
 npm test test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
+npm test **/LukeSkywalkerFaithfulFriend.spec.js # use path globbing (may look different depending on your shell)
 
 # this currently has a bug, do not use
 #npm run test-parallel   # runs tests in parallel for higher speed
@@ -50,7 +54,3 @@ Once you have vscode set up, use the `Debug All Jasmine Tests` profile or open a
 #### Debugging Tips
 - You can use the `debugger;` command in node to create a breakpoint in code that will be respected by the vscode debugger
 - VSCode has advanced breakpoint features such as conditional breakpoints that are extremely useful for debugging complex situations, we highly recommend reading the "Advanced breakpoint topics" section of this guide if you haven't used it before: https://code.visualstudio.com/docs/editor/debugging#_advanced-breakpoint-topics
-
-## Contributing
-
-For details on how to get started adding cards, see the [contributor's guide](./docs/implementing-cards.md).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ npm run lint-verbose
 # runs tsc and executes tests
 npm test
 
+# run a specific test file only
+npm test test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
+
 # this currently has a bug, do not use
 #npm run test-parallel   # runs tests in parallel for higher speed
 ```

--- a/bin/fetchdata.js
+++ b/bin/fetchdata.js
@@ -44,9 +44,9 @@ function filterValues(card) {
     filteredObj.types = getAttributeNames(card.attributes.type).split(' ');
 
     let internalName = filteredObj.title;
-    if (filteredObj.subtitle) {
-        internalName += '#' + filteredObj.subtitle;
-    }
+    internalName += filteredObj.subtitle ? '#' + filteredObj.subtitle : '';
+    // remove accents / diacritics (e.g., 'Chirrut Îmwe' -> 'Chirrut Imwe')
+    internalName = internalName.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
     filteredObj.internalName = internalName.toLowerCase().replace(/[^\w\s#]|_/g, '')
         .replace(/\s/g, '-');
 

--- a/server/game/AbilityHelper.ts
+++ b/server/game/AbilityHelper.ts
@@ -2,10 +2,12 @@ import * as AbilityLimit from './core/ability/AbilityLimit';
 import Effects from './ongoingEffects/OngoingEffectLibrary';
 import * as Costs from './costs/CostLibrary.js';
 import * as GameSystems from './gameSystems/GameSystemLibrary';
+import StateWatcherLibrary from './stateWatchers/StateWatcherLibrary';
 
 export = {
     limit: AbilityLimit,
     ongoingEffects: Effects,
     costs: Costs,
-    immediateEffects: GameSystems
+    immediateEffects: GameSystems,
+    stateWatchers: StateWatcherLibrary
 };

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -108,6 +108,15 @@ export interface IInitiateAttack extends IAttackProperties {
     targetCondition?: (card: Card, context: TriggeredAbilityContext) => boolean;
 }
 
+export interface IStateListenerProperties<TState> {
+    when: WhenType;
+    update: (currentState: TState, event: any) => TState;
+}
+
+export interface IStateListenerResetProperties {
+    when: WhenType;
+}
+
 export type traitLimit = Record<string, number>;
 
 export type EffectArg =

--- a/server/game/cards/01_SOR/LukeSkywalkerFaithfulFriend.ts
+++ b/server/game/cards/01_SOR/LukeSkywalkerFaithfulFriend.ts
@@ -31,11 +31,7 @@ export default class GrandMoffTarkinOversectorGovernor extends LeaderUnitCard {
                         return false;
                     }
 
-                    const cardsPlayed = this.cardsPlayedThisPhaseWatcher.getCurrentValue();
-                    const playedThisTurn = cardsPlayed
-                        .filter((playedCardEntry) => playedCardEntry.playedBy === context.source.controller)
-                        .map((playedCardEntry) => playedCardEntry.card as Card);
-
+                    const playedThisTurn = this.cardsPlayedThisPhaseWatcher.getCardsPlayed((playedCardEntry) => playedCardEntry.playedBy === context.source.controller);
                     return playedThisTurn.includes(card);
                 },
                 immediateEffect: AbilityHelper.immediateEffects.giveShield()

--- a/server/game/cards/01_SOR/LukeSkywalkerFaithfulFriend.ts
+++ b/server/game/cards/01_SOR/LukeSkywalkerFaithfulFriend.ts
@@ -1,0 +1,58 @@
+import AbilityHelper from '../../AbilityHelper';
+import { Card } from '../../core/card/Card';
+import { PlayableCard } from '../../core/card/CardTypes';
+import { LeaderUnitCard } from '../../core/card/LeaderUnitCard';
+import { Aspect, RelativePlayer, Trait } from '../../core/Constants';
+import { StateWatcherRegistrar } from '../../core/stateWatcher/StateWatcherRegistrar';
+import { CardsPlayedThisPhaseWatcher } from '../../stateWatchers/CardsPlayedThisPhaseWatcher';
+
+export default class GrandMoffTarkinOversectorGovernor extends LeaderUnitCard {
+    private cardsPlayedThisPhaseWatcher: CardsPlayedThisPhaseWatcher;
+
+    protected override getImplementationId() {
+        return {
+            id: '2579145458',
+            internalName: 'luke-skywalker#faithful-friend',
+        };
+    }
+
+    protected override setupStateWatchers(registrar: StateWatcherRegistrar): void {
+        this.cardsPlayedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsPlayedThisPhase(registrar, this);
+    }
+
+    protected override setupLeaderSideAbilities() {
+        this.addActionAbility({
+            title: 'Give a shield to a heroism unit you played this phase',
+            cost: [AbilityHelper.costs.abilityResourceCost(1), AbilityHelper.costs.exhaustSelf()],
+            targetResolver: {
+                controller: RelativePlayer.Self,
+                cardCondition: (card, context) => {
+                    if (!card.hasSomeAspect(Aspect.Heroism)) {
+                        return false;
+                    }
+
+                    const cardsPlayed = this.cardsPlayedThisPhaseWatcher.getCurrentValue();
+                    const playedThisTurn = cardsPlayed
+                        .filter((playedCardEntry) => playedCardEntry.playedBy === context.source.controller)
+                        .map((playedCardEntry) => playedCardEntry.card as Card);
+
+                    return playedThisTurn.includes(card);
+                },
+                immediateEffect: AbilityHelper.immediateEffects.giveShield()
+            }
+        });
+    }
+
+    protected override setupLeaderUnitSideAbilities() {
+        this.addOnAttackAbility({
+            title: 'Give a shield token to another unit',
+            optional: true,
+            targetResolver: {
+                cardCondition: (card, context) => card !== context.source,
+                immediateEffect: AbilityHelper.immediateEffects.giveShield()
+            }
+        });
+    }
+}
+
+GrandMoffTarkinOversectorGovernor.implemented = true;

--- a/server/game/cards/01_SOR/MedalCeremony.ts
+++ b/server/game/cards/01_SOR/MedalCeremony.ts
@@ -25,6 +25,7 @@ export default class MedalCeremony extends EventCard {
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 3,
+                optional: true,
                 immediateEffect: AbilityHelper.immediateEffects.giveExperience(),
                 cardCondition: (card, context) => {
                     const rebelUnitsAttackedThisPhase = this.attacksThisPhaseWatcher.getCurrentValue()

--- a/server/game/cards/01_SOR/MedalCeremony.ts
+++ b/server/game/cards/01_SOR/MedalCeremony.ts
@@ -2,7 +2,7 @@ import AbilityHelper from '../../AbilityHelper';
 import { UnitCard } from '../../core/card/CardTypes';
 import { EventCard } from '../../core/card/EventCard';
 import { TargetMode, Trait, WildcardCardType } from '../../core/Constants';
-import { AttacksThisPhaseWatcher } from '../../core/stateWatcher/AttacksThisPhaseWatcher';
+import { AttacksThisPhaseWatcher } from '../../stateWatchers/AttacksThisPhaseWatcher';
 import { StateWatcherRegistrar } from '../../core/stateWatcher/StateWatcherRegistrar';
 
 export default class MedalCeremony extends EventCard {

--- a/server/game/cards/01_SOR/MedalCeremony.ts
+++ b/server/game/cards/01_SOR/MedalCeremony.ts
@@ -28,10 +28,8 @@ export default class MedalCeremony extends EventCard {
                 optional: true,
                 immediateEffect: AbilityHelper.immediateEffects.giveExperience(),
                 cardCondition: (card, context) => {
-                    const rebelUnitsAttackedThisPhase = this.attacksThisPhaseWatcher.getCurrentValue()
-                        .filter((attack) => attack.attacker.hasSomeTrait(Trait.Rebel))
-                        .map((attack) => attack.attacker);
-
+                    const rebelUnitsAttackedThisPhase =
+                        this.attacksThisPhaseWatcher.getAttackers((attack) => attack.attacker.hasSomeTrait(Trait.Rebel));
                     return rebelUnitsAttackedThisPhase.includes(card as UnitCard);
                 }
             }

--- a/server/game/cards/01_SOR/MedalCeremony.ts
+++ b/server/game/cards/01_SOR/MedalCeremony.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../AbilityHelper';
 import { UnitCard } from '../../core/card/CardTypes';
 import { EventCard } from '../../core/card/EventCard';
-import { TargetMode, Trait, WildcardCardType } from '../../core/Constants';
+import { TargetMode, Trait } from '../../core/Constants';
 import { AttacksThisPhaseWatcher } from '../../stateWatchers/AttacksThisPhaseWatcher';
 import { StateWatcherRegistrar } from '../../core/stateWatcher/StateWatcherRegistrar';
 
@@ -15,8 +15,8 @@ export default class MedalCeremony extends EventCard {
         };
     }
 
-    protected override setupStateWatchers(stateWatcherRegistrar: StateWatcherRegistrar) {
-        this.attacksThisPhaseWatcher = new AttacksThisPhaseWatcher(stateWatcherRegistrar, this);
+    protected override setupStateWatchers(registrar: StateWatcherRegistrar) {
+        this.attacksThisPhaseWatcher = AbilityHelper.stateWatchers.attacksThisPhase(registrar, this);
     }
 
     public override setupCardAbilities() {

--- a/server/game/cards/01_SOR/MedalCeremony.ts
+++ b/server/game/cards/01_SOR/MedalCeremony.ts
@@ -1,0 +1,41 @@
+import AbilityHelper from '../../AbilityHelper';
+import { UnitCard } from '../../core/card/CardTypes';
+import { EventCard } from '../../core/card/EventCard';
+import { TargetMode, Trait, WildcardCardType } from '../../core/Constants';
+import { AttacksThisPhaseWatcher } from '../../core/stateWatcher/AttacksThisPhaseWatcher';
+import { StateWatcherRegistrar } from '../../core/stateWatcher/StateWatcherRegistrar';
+
+export default class MedalCeremony extends EventCard {
+    private attacksThisPhaseWatcher: AttacksThisPhaseWatcher;
+
+    protected override getImplementationId() {
+        return {
+            id: '4536594859',
+            internalName: 'medal-ceremony',
+        };
+    }
+
+    protected override setupStateWatchers(stateWatcherRegistrar: StateWatcherRegistrar) {
+        this.attacksThisPhaseWatcher = new AttacksThisPhaseWatcher(stateWatcherRegistrar, this);
+    }
+
+    public override setupCardAbilities() {
+        this.setEventAbility({
+            title: 'Give an experience to each of up to three Rebel units that attacked this phase',
+            targetResolver: {
+                mode: TargetMode.UpTo,
+                numCards: 3,
+                immediateEffect: AbilityHelper.immediateEffects.giveExperience(),
+                cardCondition: (card, context) => {
+                    const rebelUnitsAttackedThisPhase = this.attacksThisPhaseWatcher.getCurrentValue()
+                        .filter((attack) => attack.attacker.hasSomeTrait(Trait.Rebel))
+                        .map((attack) => attack.attacker);
+
+                    return rebelUnitsAttackedThisPhase.includes(card as UnitCard);
+                }
+            }
+        });
+    }
+}
+
+MedalCeremony.implemented = true;

--- a/server/game/cards/01_SOR/VanguardAce.ts
+++ b/server/game/cards/01_SOR/VanguardAce.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../core/card/NonLeaderUnitCard';
-import { CardsPlayedThisPhaseWatcher } from '../../core/stateWatcher/CardsPlayedThisPhaseWatcher';
+import { CardsPlayedThisPhaseWatcher } from '../../stateWatchers/CardsPlayedThisPhaseWatcher';
 import { StateWatcherRegistrar } from '../../core/stateWatcher/StateWatcherRegistrar';
 
 export default class VanguardAce extends NonLeaderUnitCard {

--- a/server/game/cards/01_SOR/VanguardAce.ts
+++ b/server/game/cards/01_SOR/VanguardAce.ts
@@ -1,0 +1,38 @@
+import AbilityHelper from '../../AbilityHelper';
+import { PlayableCard } from '../../core/card/CardTypes';
+import { NonLeaderUnitCard } from '../../core/card/NonLeaderUnitCard';
+import { Location, RelativePlayer, Trait, WildcardCardType } from '../../core/Constants';
+import { CardsPlayedThisPhaseWatcher } from '../../core/stateWatcher/CardsPlayedThisPhaseWatcher';
+import { StateWatcherRegistrar } from '../../core/stateWatcher/StateWatcherRegistrar';
+
+export default class VanguardAce extends NonLeaderUnitCard {
+    private cardsPlayedThisWatcher: CardsPlayedThisPhaseWatcher;
+
+    protected override getImplementationId() {
+        return {
+            id: '3018017739',
+            internalName: 'vanguard-ace',
+        };
+    }
+
+    protected override setupStateWatchers(stateWatcherRegistrar: StateWatcherRegistrar) {
+        this.cardsPlayedThisWatcher = new CardsPlayedThisPhaseWatcher(
+            stateWatcherRegistrar,
+            this,
+            (card: PlayableCard) => card.controller === this.owner
+        );
+    }
+
+    public override setupCardAbilities() {
+        this.addWhenPlayedAbility({
+            title: 'Give 2 experience tokens to a friendly Imperial unit',
+            targetResolver: {
+                controller: RelativePlayer.Self,
+                cardCondition: (card) => card.hasSomeTrait(Trait.Imperial) && card !== this,
+                immediateEffect: AbilityHelper.immediateEffects.giveExperience()
+            }
+        });
+    }
+}
+
+VanguardAce.implemented = true;

--- a/server/game/cards/01_SOR/VanguardAce.ts
+++ b/server/game/cards/01_SOR/VanguardAce.ts
@@ -1,5 +1,4 @@
 import AbilityHelper from '../../AbilityHelper';
-import { PlayableCard } from '../../core/card/CardTypes';
 import { NonLeaderUnitCard } from '../../core/card/NonLeaderUnitCard';
 import { CardsPlayedThisPhaseWatcher } from '../../core/stateWatcher/CardsPlayedThisPhaseWatcher';
 import { StateWatcherRegistrar } from '../../core/stateWatcher/StateWatcherRegistrar';
@@ -15,10 +14,7 @@ export default class VanguardAce extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(stateWatcherRegistrar: StateWatcherRegistrar) {
-        this.cardsPlayedThisWatcher = new CardsPlayedThisPhaseWatcher(
-            stateWatcherRegistrar,
-            this
-        );
+        this.cardsPlayedThisWatcher = new CardsPlayedThisPhaseWatcher(stateWatcherRegistrar, this);
     }
 
     public override setupCardAbilities() {
@@ -26,6 +22,7 @@ export default class VanguardAce extends NonLeaderUnitCard {
             title: 'Give one experience for each card you played this turn',
             immediateEffect: AbilityHelper.immediateEffects.giveExperience(() => {
                 const cardsPlayedThisPhase = this.cardsPlayedThisWatcher.getCurrentValue();
+
                 const experienceCount = cardsPlayedThisPhase.filter((playedCardEntry) =>
                     playedCardEntry.playedBy === this.controller &&
                     playedCardEntry.card !== this

--- a/server/game/cards/01_SOR/VanguardAce.ts
+++ b/server/game/cards/01_SOR/VanguardAce.ts
@@ -20,12 +20,12 @@ export default class VanguardAce extends NonLeaderUnitCard {
     public override setupCardAbilities() {
         this.addWhenPlayedAbility({
             title: 'Give one experience for each card you played this turn',
-            immediateEffect: AbilityHelper.immediateEffects.giveExperience(() => {
+            immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => {
                 const cardsPlayedThisPhase = this.cardsPlayedThisWatcher.getCurrentValue();
 
                 const experienceCount = cardsPlayedThisPhase.filter((playedCardEntry) =>
-                    playedCardEntry.playedBy === this.controller &&
-                    playedCardEntry.card !== this
+                    playedCardEntry.playedBy === context.source.controller &&
+                    playedCardEntry.card !== context.source
                 ).length;
 
                 return { amount: experienceCount };

--- a/server/game/cards/01_SOR/VanguardAce.ts
+++ b/server/game/cards/01_SOR/VanguardAce.ts
@@ -19,16 +19,13 @@ export default class VanguardAce extends NonLeaderUnitCard {
 
     public override setupCardAbilities() {
         this.addWhenPlayedAbility({
-            title: 'Give one experience for each card you played this turn',
+            title: 'Give one experience for each other card you played this turn',
             immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => {
-                const cardsPlayedThisPhase = this.cardsPlayedThisWatcher.getCurrentValue();
+                const otherFriendlyCardsPlayedThisPhase = this.cardsPlayedThisWatcher.getCardsPlayed(
+                    (cardPlay) => cardPlay.playedBy === context.source.controller && cardPlay.card !== context.source
+                );
 
-                const experienceCount = cardsPlayedThisPhase.filter((playedCardEntry) =>
-                    playedCardEntry.playedBy === context.source.controller &&
-                    playedCardEntry.card !== context.source
-                ).length;
-
-                return { amount: experienceCount };
+                return { amount: otherFriendlyCardsPlayedThisPhase.length };
             })
         });
     }

--- a/server/game/cards/01_SOR/VanguardAce.ts
+++ b/server/game/cards/01_SOR/VanguardAce.ts
@@ -13,8 +13,8 @@ export default class VanguardAce extends NonLeaderUnitCard {
         };
     }
 
-    protected override setupStateWatchers(stateWatcherRegistrar: StateWatcherRegistrar) {
-        this.cardsPlayedThisWatcher = new CardsPlayedThisPhaseWatcher(stateWatcherRegistrar, this);
+    protected override setupStateWatchers(registrar: StateWatcherRegistrar) {
+        this.cardsPlayedThisWatcher = AbilityHelper.stateWatchers.cardsPlayedThisPhase(registrar, this);
     }
 
     public override setupCardAbilities() {

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -321,4 +321,11 @@ export enum AbilityRestriction {
 
 export enum StateWatcherName {
     CardsPlayedThisPhase = 'CardsPlayedThisPhase',
+
+    // TODO STATE WATCHERS: watcher types needed
+    // - unit defeated: Iden, Emperor's Legion, Brutal Traditions, Spark of Hope, Bravado,
+    // - card played: Luke leader, Vader leader, Lothal Insurgent, Vanguard Ace, Guardian of the Whills, Relentless, Omega
+    // - attacked / damaged base: Cassian leader, Forced Surrender, Ephant Mon, Rule with Respect
+    // - attacked: Medal Ceremony, Bo-Katan leader, Asajj Ventress,
+    // - discarded: Kylo's TIE Silencer?
 }

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -318,3 +318,7 @@ export enum AbilityRestriction {
     ReceiveDamage = 'receiveDamage',
     TriggerAbilities = 'triggerAbilities',
 }
+
+export enum StateWatcherName {
+    CardsPlayedThisPhase = 'CardsPlayedThisPhase',
+}

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -328,6 +328,7 @@ export enum StateWatcherName {
     // - unit defeated: Iden, Emperor's Legion, Brutal Traditions, Spark of Hope, Bravado
     // - damaged base: Cassian leader, Forced Surrender
     // - card played: Luke leader, Vader leader, Lothal Insurgent, Vanguard Ace, Guardian of the Whills, Relentless, Omega
+    // - entered play: Boba unit
     // - attacked base: Ephant Mon, Rule with Respect
     // - attacked with unit type: Medal Ceremony, Bo-Katan leader, Asajj Ventress
     // - discarded: Kylo's TIE Silencer?

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -320,12 +320,14 @@ export enum AbilityRestriction {
 }
 
 export enum StateWatcherName {
-    CardsPlayedThisPhase = 'CardsPlayedThisPhase',
+    CardsPlayedThisPhase = 'cardsPlayedThisPhase',
+    UnitsAttackedThisPhase = 'unitsAttackedThisPhase',
 
     // TODO STATE WATCHERS: watcher types needed
-    // - unit defeated: Iden, Emperor's Legion, Brutal Traditions, Spark of Hope, Bravado,
+    // - unit defeated: Iden, Emperor's Legion, Brutal Traditions, Spark of Hope, Bravado
+    // - damaged base: Cassian leader, Forced Surrender
     // - card played: Luke leader, Vader leader, Lothal Insurgent, Vanguard Ace, Guardian of the Whills, Relentless, Omega
-    // - attacked / damaged base: Cassian leader, Forced Surrender, Ephant Mon, Rule with Respect
-    // - attacked: Medal Ceremony, Bo-Katan leader, Asajj Ventress,
+    // - attacked base: Ephant Mon, Rule with Respect
+    // - attacked with unit type: Medal Ceremony, Bo-Katan leader, Asajj Ventress
     // - discarded: Kylo's TIE Silencer?
 }

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -33,6 +33,7 @@ const { cards } = require('../cards/Index.js');
 const { EffectName, EventName, Location, TokenName } = require('./Constants.js');
 const { BaseStepWithPipeline } = require('./gameSteps/BaseStepWithPipeline.js');
 const { default: Shield } = require('../cards/01_SOR/Shield.js');
+const { StateWatcherRegistrar } = require('./stateWatcher/StateWatcherRegistrar.js');
 
 class Game extends EventEmitter {
     constructor(details, options = {}) {
@@ -66,6 +67,7 @@ class Game extends EventEmitter {
         this.initiativePlayer = null;
         this.actionPhaseActivePlayer = null;
         this.tokenFactories = null;
+        this.stateWatcherRegistrar = new StateWatcherRegistrar(this);
 
         this.shortCardData = options.shortCardData || [];
 

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.js
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.js
@@ -37,9 +37,9 @@ class CardTargetResolver {
             if (context.stage === Stage.PreTarget && this.dependentCost && !this.dependentCost.canPay(contextCopy)) {
                 return false;
             }
-            return (!properties.cardCondition || properties.cardCondition(card, contextCopy)) &&
-                   (!this.dependentTarget || this.dependentTarget.hasLegalTarget(contextCopy)) &&
-                   (properties.immediateEffect.length === 0 || properties.immediateEffect.some((gameSystem) => gameSystem.hasLegalTarget(contextCopy)));
+            return (!this.dependentTarget || this.dependentTarget.hasLegalTarget(contextCopy)) &&
+                   (properties.immediateEffect.length === 0 || properties.immediateEffect.some((gameSystem) => gameSystem.hasLegalTarget(contextCopy)) &&
+                   (!properties.cardCondition || properties.cardCondition(card, contextCopy)));
         };
         return CardSelector.for(Object.assign({}, properties, { cardCondition: cardCondition, targets: true }));
     }

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -13,6 +13,7 @@ import CardAbility from '../ability/CardAbility';
 import type Shield from '../../cards/01_SOR/Shield';
 import { KeywordInstance } from '../ability/KeywordInstance';
 import * as KeywordHelpers from '../ability/KeywordHelpers';
+import { StateWatcherRegistrar } from '../stateWatcher/StateWatcherRegistrar';
 
 // required for mixins to be based on this class
 export type CardConstructor = new (...args: any[]) => Card;
@@ -107,6 +108,7 @@ export class Card extends OngoingEffectSource {
         }
 
         this.setupCardAbilities(AbilityHelper);
+        this.setupStateWatchers(this.owner.game.stateWatcherRegistrar);
         this.activateAbilityInitializersForTypes(AbilityType.Action);
     }
 
@@ -203,6 +205,10 @@ export class Card extends OngoingEffectSource {
         Contract.assertArraySize(args, 2);
 
         return [args[0] as Player, args[1]];
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    protected setupStateWatchers(stateWatcherRegistrar: StateWatcherRegistrar) {
     }
 
     /**

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -212,7 +212,7 @@ export class Card extends OngoingEffectSource {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    protected setupStateWatchers(stateWatcherRegistrar: StateWatcherRegistrar) {
+    protected setupStateWatchers(registrar: StateWatcherRegistrar) {
     }
 
     public createActionAbility(properties: IActionAbilityProps): ActionAbility {

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -341,6 +341,16 @@ export class Card extends OngoingEffectSource {
     }
 
 
+    // ******************************************* ASPECT HELPERS *******************************************
+    public hasSomeAspect(aspects: Set<Aspect> | Aspect | Aspect[]): boolean {
+        return this.hasSome(aspects, this.aspects);
+    }
+
+    public hasEveryAspect(aspects: Set<Aspect> | Aspect[]): boolean {
+        return this.hasEvery(aspects, this.aspects);
+    }
+
+
     // *************************************** EFFECT HELPERS ***************************************
     public isBlank(): boolean {
         return this.hasEffect(EffectName.Blank);

--- a/server/game/core/card/CardTypes.ts
+++ b/server/game/core/card/CardTypes.ts
@@ -39,7 +39,7 @@ export type CardWithPrintedPower =
 export type CardWithTriggeredAbilities = InPlayCard;
 export type CardWithConstantAbilities = InPlayCard;
 
-export type CardWithExhaustProperty = PlayableOrDeployableCard;
+export type CardWithExhaustProperty = PlayableOrDeployableCardTypes;
 
 export type AnyCard =
     BaseCard |
@@ -51,7 +51,13 @@ export type AnyCard =
     LeaderUnitCard |
     TokenUnitCard;
 
+/** Type union for any card type that can be played (not deployed) */
+export type PlayableCard =
+    EventCard |
+    UpgradeCard |
+    NonLeaderUnitCard;
+
 // Base is the only type of card that isn't in the PlayableOrDeployable subclass
-type PlayableOrDeployableCard = Exclude<AnyCard, BaseCard>;
+type PlayableOrDeployableCardTypes = Exclude<AnyCard, BaseCard>;
 
 type InPlayCard = Exclude<AnyCard, BaseCard | EventCard>;

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -23,13 +23,6 @@ export class InPlayCard extends PlayableOrDeployableCard {
     protected _triggeredAbilities: TriggeredAbility[] = [];
     protected _constantAbilities: IConstantAbility[] = [];
 
-    private _enteredPlayThisRound?: boolean = null;
-
-    public get enteredPlayThisRound(): boolean {
-        Contract.assertNotNullLike(this._enteredPlayThisRound);
-        return this._enteredPlayThisRound;
-    }
-
     // ********************************************** CONSTRUCTOR **********************************************
     public constructor(owner: Player, cardData: any) {
         super(owner, cardData);
@@ -132,18 +125,6 @@ export class InPlayCard extends PlayableOrDeployableCard {
         return new TriggeredAbility(this.game, this, properties);
     }
 
-
-    // ******************************************** PLAY / DEFEAT MANAGEMENT ********************************************
-    // TODO LEADER: TODO TOKEN: add custom defeat logic here. figure out how it should interact with player.defeatCard()
-    // and the DefeatCardSystem
-
-    private resetEnteredPlayThisRound() {
-        // if the value is null, the card is no longer in play
-        if (this._enteredPlayThisRound !== null) {
-            this._enteredPlayThisRound = false;
-        }
-    }
-
     // ******************************************** ABILITY STATE MANAGEMENT ********************************************
     /** Update the context of each constant ability. Used when the card's controller has changed. */
     public updateConstantAbilityContexts() {
@@ -163,12 +144,6 @@ export class InPlayCard extends PlayableOrDeployableCard {
         // where we maybe wouldn't reset events / effects / limits?
         this.updateTriggeredAbilityEvents(prevLocation, this.location);
         this.updateConstantAbilityEffects(prevLocation, this.location);
-
-        this._enteredPlayThisRound = EnumHelpers.isArena(this.location) ? true : null;
-
-        // register a handler to reset the enteredPlayThisRound flag after the end of the round
-        // TODO: we need a way to remove these handlers when the card leaves play
-        this.game.on(EventName.OnRoundEndedCleanup, this.resetEnteredPlayThisRound);
     }
 
     /** Register / un-register the event triggers for any triggered abilities */

--- a/server/game/core/cardSelector/UpToXCardSelector.js
+++ b/server/game/core/cardSelector/UpToXCardSelector.js
@@ -9,7 +9,7 @@ class UpToXCardSelector extends BaseCardSelector {
 
     /** @override */
     defaultActivePromptTitle() {
-        return this.numCards === 1 ? 'Select a character' : `Select ${this.numCards} characters`;
+        return this.numCards === 1 ? 'Select a card' : `Select ${this.numCards} cards`;
     }
 
     /** @override */

--- a/server/game/core/stateWatcher/AttacksThisPhaseWatcher.ts
+++ b/server/game/core/stateWatcher/AttacksThisPhaseWatcher.ts
@@ -1,0 +1,53 @@
+import { StateWatcher } from './StateWatcher';
+import { StateWatcherName } from '../Constants';
+import { StateWatcherRegistrar } from './StateWatcherRegistrar';
+import Player from '../Player';
+import { UnitCard } from '../card/CardTypes';
+import { Card } from '../card/Card';
+import { BaseCard } from '../card/BaseCard';
+
+export interface AttackEntry {
+    attacker: UnitCard,
+    attackingPlayer: Player,
+    target: UnitCard | BaseCard,
+    defendingPlayer: Player
+}
+
+export type IAttacksThisPhase = AttackEntry[];
+
+export class AttacksThisPhaseWatcher extends StateWatcher<IAttacksThisPhase> {
+    public constructor(
+        registrar: StateWatcherRegistrar,
+        card: Card
+    ) {
+        super(StateWatcherName.UnitsAttackedThisPhase, registrar, card);
+    }
+
+    /**
+     * Returns an array of {@link AttackEntry} objects representing every attack this
+     * phase so far. Lists the attacker and target cards and which player was attacking
+     * or defending.
+     */
+    public override getCurrentValue(): IAttacksThisPhase {
+        return super.getCurrentValue();
+    }
+
+    protected override setupWatcher() {
+        this.addUpdater({
+            when: {
+                onAttackDeclared: () => true,
+            },
+            update: (currentState: IAttacksThisPhase, event: any) =>
+                currentState.concat({
+                    attacker: event.attack.attacker,
+                    attackingPlayer: event.attack.attacker.controller,
+                    target: event.attack.target,
+                    defendingPlayer: event.attack.target.controller
+                })
+        });
+    }
+
+    protected override getResetValue(): IAttacksThisPhase {
+        return [];
+    }
+}

--- a/server/game/core/stateWatcher/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/core/stateWatcher/CardsPlayedThisPhaseWatcher.ts
@@ -1,0 +1,36 @@
+import { StateWatcher } from './StateWatcher';
+import { StateWatcherName } from '../Constants';
+import { StateWatcherRegistrar } from './StateWatcherRegistrar';
+import Player from '../Player';
+import { PlayableCard } from '../card/CardTypes';
+import Game from '../Game';
+import { Card } from '../card/Card';
+
+export type ICardsPlayedThisPhase = Map<Player, PlayableCard[]>;
+
+export class CardsPlayedThisPhaseWatcher extends StateWatcher<ICardsPlayedThisPhase> {
+    public override readonly resetValue = (game: Game) => {
+        const result = new Map<Player, PlayableCard[]>();
+        game.getPlayers().forEach((player) => result.set(player, []));
+        return result;
+    };
+
+    public constructor(registrar: StateWatcherRegistrar, card: Card) {
+        super(StateWatcherName.CardsPlayedThisPhase, registrar, card);
+    }
+
+    protected override setupWatcher() {
+        // on card played, add the card to the player's list of cards played this phase
+        this.addUpdater({
+            when: {
+                onCardPlayed: () => true,
+            },
+            update: (currentState: ICardsPlayedThisPhase, event: any) => {
+                const { player, card } = event;
+                const playerCards = currentState.get(player);
+                playerCards.push(card);
+                return currentState;
+            }
+        });
+    }
+}

--- a/server/game/core/stateWatcher/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/core/stateWatcher/CardsPlayedThisPhaseWatcher.ts
@@ -6,13 +6,18 @@ import { PlayableCard } from '../card/CardTypes';
 import Game from '../Game';
 import { Card } from '../card/Card';
 
-export type ICardsPlayedThisPhase = PlayableCard[];
+export interface PlayedCardEntry {
+    card: PlayableCard,
+    playedBy: Player
+}
+
+export type ICardsPlayedThisPhase = PlayedCardEntry[];
 
 export class CardsPlayedThisPhaseWatcher extends StateWatcher<ICardsPlayedThisPhase> {
     public constructor(
         registrar: StateWatcherRegistrar,
         card: Card,
-        private readonly filter: (card: PlayableCard) => boolean = () => true
+        private readonly addCardCondition: (card: PlayableCard) => boolean = () => true
     ) {
         super(StateWatcherName.CardsPlayedThisPhase, registrar, card);
     }
@@ -24,7 +29,9 @@ export class CardsPlayedThisPhaseWatcher extends StateWatcher<ICardsPlayedThisPh
                 onCardPlayed: () => true,
             },
             update: (currentState: ICardsPlayedThisPhase, event: any) => {
-                return this.filter(event.card) ? currentState.concat(event.card) : currentState;
+                return this.addCardCondition(event.card)
+                    ? currentState.concat({ card: event.card, playedBy: event.card.controller })
+                    : currentState;
             }
         });
     }

--- a/server/game/core/stateWatcher/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/core/stateWatcher/CardsPlayedThisPhaseWatcher.ts
@@ -16,10 +16,17 @@ export type ICardsPlayedThisPhase = PlayedCardEntry[];
 export class CardsPlayedThisPhaseWatcher extends StateWatcher<ICardsPlayedThisPhase> {
     public constructor(
         registrar: StateWatcherRegistrar,
-        card: Card,
-        private readonly addCardCondition: (card: PlayableCard) => boolean = () => true
+        card: Card
     ) {
         super(StateWatcherName.CardsPlayedThisPhase, registrar, card);
+    }
+
+    /**
+     * Returns an array of {@link PlayedCardEntry} objects representing every card played
+     * in this phase so far and the player who played that card
+     */
+    public override getCurrentValue(): ICardsPlayedThisPhase {
+        return super.getCurrentValue();
     }
 
     protected override setupWatcher() {
@@ -28,11 +35,8 @@ export class CardsPlayedThisPhaseWatcher extends StateWatcher<ICardsPlayedThisPh
             when: {
                 onCardPlayed: () => true,
             },
-            update: (currentState: ICardsPlayedThisPhase, event: any) => {
-                return this.addCardCondition(event.card)
-                    ? currentState.concat({ card: event.card, playedBy: event.card.controller })
-                    : currentState;
-            }
+            update: (currentState: ICardsPlayedThisPhase, event: any) =>
+                currentState.concat({ card: event.card, playedBy: event.card.controller })
         });
     }
 

--- a/server/game/core/stateWatcher/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/core/stateWatcher/CardsPlayedThisPhaseWatcher.ts
@@ -6,16 +6,14 @@ import { PlayableCard } from '../card/CardTypes';
 import Game from '../Game';
 import { Card } from '../card/Card';
 
-export type ICardsPlayedThisPhase = Map<Player, PlayableCard[]>;
+export type ICardsPlayedThisPhase = PlayableCard[];
 
 export class CardsPlayedThisPhaseWatcher extends StateWatcher<ICardsPlayedThisPhase> {
-    public override readonly resetValue = (game: Game) => {
-        const result = new Map<Player, PlayableCard[]>();
-        game.getPlayers().forEach((player) => result.set(player, []));
-        return result;
-    };
-
-    public constructor(registrar: StateWatcherRegistrar, card: Card) {
+    public constructor(
+        registrar: StateWatcherRegistrar,
+        card: Card,
+        private readonly filter: (card: PlayableCard) => boolean = () => true
+    ) {
         super(StateWatcherName.CardsPlayedThisPhase, registrar, card);
     }
 
@@ -26,11 +24,12 @@ export class CardsPlayedThisPhaseWatcher extends StateWatcher<ICardsPlayedThisPh
                 onCardPlayed: () => true,
             },
             update: (currentState: ICardsPlayedThisPhase, event: any) => {
-                const { player, card } = event;
-                const playerCards = currentState.get(player);
-                playerCards.push(card);
-                return currentState;
+                return this.filter(event.card) ? currentState.concat(event.card) : currentState;
             }
         });
+    }
+
+    protected override getResetValue(): ICardsPlayedThisPhase {
+        return [];
     }
 }

--- a/server/game/core/stateWatcher/StateWatcher.ts
+++ b/server/game/core/stateWatcher/StateWatcher.ts
@@ -1,0 +1,61 @@
+import { IStateListenerResetProperties, IStateListenerProperties } from '../../Interfaces';
+import { StateWatcherName } from '../Constants';
+import Player from '../Player';
+import Contract from '../utils/Contract';
+import { StateWatcherRegistrar } from './StateWatcherRegistrar';
+
+export abstract class StateWatcher<TState> {
+    public readonly abstract resetValue: TState;
+
+    private readonly ownerKey: string;
+    private stateUpdaters: IStateListenerProperties<TState>[] = [];
+    private stateResetTrigger?: IStateListenerResetProperties = null;
+
+    public constructor(
+        public readonly name: StateWatcherName,
+        private readonly registrar: StateWatcherRegistrar,
+        isGlobalWatcher: boolean,
+        owner?: Player
+    ) {
+        this.ownerKey = registrar.generateOwnerKey(isGlobalWatcher, owner);
+        if (registrar.isRegistered(this.ownerKey, this.name)) {
+            return;
+        }
+
+        this.registrar.register(this.ownerKey, this.name, this.generateListenerRegistrations());
+    }
+
+    protected abstract setupWatcher(): void;
+
+    public getCurrentValue(): TState {
+        return this.registrar.getStateValue(this.ownerKey, this.name) as TState;
+    }
+
+    protected addUpdater(properties: IStateListenerProperties<TState>) {
+        this.stateUpdaters.push(properties);
+    }
+
+    protected setResetTrigger(properties: IStateListenerResetProperties) {
+        if (!Contract.assertTrue(this.stateResetTrigger === null, 'Reset trigger is already set')) {
+            return;
+        }
+
+        this.stateResetTrigger = properties;
+    }
+
+    private generateListenerRegistrations(): IStateListenerProperties<TState>[] {
+        this.setupWatcher();
+
+        if (
+            !Contract.assertTrue(this.stateUpdaters.length > 0, 'No state updaters registered') ||
+            !Contract.assertNotNullLike(this.stateResetTrigger, 'State reset trigger not set')
+        ) {
+            return [];
+        }
+
+        const stateResetUpdater: IStateListenerProperties<TState> =
+            Object.assign(this.stateResetTrigger, { update: () => this.resetValue });
+
+        return this.stateUpdaters.concat(stateResetUpdater);
+    }
+}

--- a/server/game/core/stateWatcher/StateWatcher.ts
+++ b/server/game/core/stateWatcher/StateWatcher.ts
@@ -1,34 +1,44 @@
 import { IStateListenerResetProperties, IStateListenerProperties } from '../../Interfaces';
-import { StateWatcherName } from '../Constants';
+import { Card } from '../card/Card';
+import { PhaseName, StateWatcherName } from '../Constants';
+import Game from '../Game';
 import Player from '../Player';
 import Contract from '../utils/Contract';
 import { StateWatcherRegistrar } from './StateWatcherRegistrar';
 
 export abstract class StateWatcher<TState> {
-    public readonly abstract resetValue: TState;
+    public readonly abstract resetValue: (game: Game) => TState;
 
-    private readonly ownerKey: string;
+    private readonly owner: Player;
+    private readonly registrationKey: string;
     private stateUpdaters: IStateListenerProperties<TState>[] = [];
-    private stateResetTrigger?: IStateListenerResetProperties = null;
+
+    // the default state reset trigger is the end of the phase
+    private stateResetTrigger?: IStateListenerResetProperties = {
+        when: {
+            onPhaseEnded: (event) => event.phase === PhaseName.Action
+        }
+    };
 
     public constructor(
         public readonly name: StateWatcherName,
         private readonly registrar: StateWatcherRegistrar,
-        isGlobalWatcher: boolean,
-        owner?: Player
+        card: Card
     ) {
-        this.ownerKey = registrar.generateOwnerKey(isGlobalWatcher, owner);
-        if (registrar.isRegistered(this.ownerKey, this.name)) {
+        this.owner = card.owner;
+        this.registrationKey = card.internalName + '.' + name;
+
+        if (registrar.isRegistered(this.owner, this.registrationKey)) {
             return;
         }
 
-        this.registrar.register(this.ownerKey, this.name, this.generateListenerRegistrations());
+        this.registrar.register(this.owner, this.registrationKey, this.generateListenerRegistrations());
     }
 
     protected abstract setupWatcher(): void;
 
     public getCurrentValue(): TState {
-        return this.registrar.getStateValue(this.ownerKey, this.name) as TState;
+        return this.registrar.getStateValue(this.owner, this.registrationKey) as TState;
     }
 
     protected addUpdater(properties: IStateListenerProperties<TState>) {
@@ -47,14 +57,13 @@ export abstract class StateWatcher<TState> {
         this.setupWatcher();
 
         if (
-            !Contract.assertTrue(this.stateUpdaters.length > 0, 'No state updaters registered') ||
-            !Contract.assertNotNullLike(this.stateResetTrigger, 'State reset trigger not set')
+            !Contract.assertTrue(this.stateUpdaters.length > 0, 'No state updaters registered')
         ) {
             return [];
         }
 
         const stateResetUpdater: IStateListenerProperties<TState> =
-            Object.assign(this.stateResetTrigger, { update: () => this.resetValue });
+            Object.assign(this.stateResetTrigger, { update: () => this.resetValue(this.registrar.game) });
 
         return this.stateUpdaters.concat(stateResetUpdater);
     }

--- a/server/game/core/stateWatcher/StateWatcher.ts
+++ b/server/game/core/stateWatcher/StateWatcher.ts
@@ -1,7 +1,6 @@
 import { IStateListenerResetProperties, IStateListenerProperties } from '../../Interfaces';
 import { Card } from '../card/Card';
 import { PhaseName, StateWatcherName } from '../Constants';
-import Game from '../Game';
 import Player from '../Player';
 import Contract from '../utils/Contract';
 import { StateWatcherRegistrar } from './StateWatcherRegistrar';
@@ -26,11 +25,11 @@ export abstract class StateWatcher<TState> {
         this.owner = card.owner;
         this.registrationKey = card.internalName + '.' + name;
 
-        if (registrar.isRegistered(this.owner, this.registrationKey)) {
+        if (registrar.isRegistered(this.registrationKey)) {
             return;
         }
 
-        this.registrar.register(this.owner, this.registrationKey, this.getResetValue(), this.generateListenerRegistrations());
+        this.registrar.register(this.registrationKey, this.getResetValue(), this.generateListenerRegistrations());
     }
 
     protected abstract setupWatcher(): void;
@@ -38,7 +37,7 @@ export abstract class StateWatcher<TState> {
     protected abstract getResetValue(): TState;
 
     public getCurrentValue(): TState {
-        return this.registrar.getStateValue(this.owner, this.registrationKey) as TState;
+        return this.registrar.getStateValue(this.registrationKey) as TState;
     }
 
     protected addUpdater(properties: IStateListenerProperties<TState>) {

--- a/server/game/core/stateWatcher/StateWatcher.ts
+++ b/server/game/core/stateWatcher/StateWatcher.ts
@@ -7,8 +7,6 @@ import Contract from '../utils/Contract';
 import { StateWatcherRegistrar } from './StateWatcherRegistrar';
 
 export abstract class StateWatcher<TState> {
-    public readonly abstract resetValue: (game: Game) => TState;
-
     private readonly owner: Player;
     private readonly registrationKey: string;
     private stateUpdaters: IStateListenerProperties<TState>[] = [];
@@ -32,10 +30,12 @@ export abstract class StateWatcher<TState> {
             return;
         }
 
-        this.registrar.register(this.owner, this.registrationKey, this.generateListenerRegistrations());
+        this.registrar.register(this.owner, this.registrationKey, this.getResetValue(), this.generateListenerRegistrations());
     }
 
     protected abstract setupWatcher(): void;
+
+    protected abstract getResetValue(): TState;
 
     public getCurrentValue(): TState {
         return this.registrar.getStateValue(this.owner, this.registrationKey) as TState;
@@ -63,7 +63,7 @@ export abstract class StateWatcher<TState> {
         }
 
         const stateResetUpdater: IStateListenerProperties<TState> =
-            Object.assign(this.stateResetTrigger, { update: () => this.resetValue(this.registrar.game) });
+            Object.assign(this.stateResetTrigger, { update: () => this.getResetValue() });
 
         return this.stateUpdaters.concat(stateResetUpdater);
     }

--- a/server/game/core/stateWatcher/StateWatcherRegistrar.ts
+++ b/server/game/core/stateWatcher/StateWatcherRegistrar.ts
@@ -13,10 +13,13 @@ export class StateWatcherRegistrar {
         return this.watchedState.has(owner) && this.watchedState.get(owner).has(watcherKey);
     }
 
-    public register(owner: Player, watcherKey: string, listeners: IStateListenerProperties<any>[]) {
+    public register(owner: Player, watcherKey: string, initialValue: any, listeners: IStateListenerProperties<any>[]) {
         if (this.isRegistered(owner, watcherKey)) {
             return;
         }
+
+        // set the initial state value
+        this.setStateValue(owner, watcherKey, initialValue);
 
         for (const listener of listeners) {
             const eventNames = Object.keys(listener.when);

--- a/server/game/core/stateWatcher/StateWatcherRegistrar.ts
+++ b/server/game/core/stateWatcher/StateWatcherRegistrar.ts
@@ -3,6 +3,11 @@ import Game from '../Game';
 import Player from '../Player';
 import Contract from '../utils/Contract';
 
+/**
+ * Helper for managing the operation of {@link StateWatcher} implementations.
+ * Holds the state objects that the watchers interact with, registers the
+ * triggers for updating them, and tracks which watcher types are registered.
+ */
 export class StateWatcherRegistrar {
     private watchedState = new Map<string, any>();
 

--- a/server/game/core/stateWatcher/StateWatcherRegistrar.ts
+++ b/server/game/core/stateWatcher/StateWatcherRegistrar.ts
@@ -1,0 +1,69 @@
+import { IStateListenerProperties } from '../../Interfaces';
+import { StateWatcherName } from '../Constants';
+import Game from '../Game';
+import Player from '../Player';
+import Contract from '../utils/Contract';
+
+export class StateWatcherRegistrar {
+    private watchedState = new Map<string, Map<StateWatcherName, any>>();
+
+    public constructor(private game: Game) {
+    }
+
+    public generateOwnerKey(isGlobalWatcher: boolean, owner?: Player) {
+        return isGlobalWatcher ? 'global' : 'p_' + owner.name;
+    }
+
+    public isRegistered(ownerKey: string, stateName: StateWatcherName) {
+        return this.watchedState.has(ownerKey) && this.watchedState[ownerKey].has(stateName);
+    }
+
+    public register(ownerKey: string, stateName: StateWatcherName, listeners: IStateListenerProperties<any>[]) {
+        if (this.isRegistered(ownerKey, stateName)) {
+            return;
+        }
+
+        for (const listener of listeners) {
+            const eventNames = Object.keys(listener.when);
+
+            // build a handler that will use the listener's update handler to generate a new state value and then store it
+            const stateUpdateHandler = (event) => {
+                const currentStateValue = this.getStateValue(ownerKey, stateName);
+                const updatedStateValue = listener.update(currentStateValue, event);
+                this.setStateValue(ownerKey, stateName, updatedStateValue);
+            };
+
+            eventNames.forEach((eventName) => this.game.on(eventName, stateUpdateHandler));
+        }
+    }
+
+    public getStateValue(ownerKey: string, stateName: StateWatcherName): any {
+        const ownerStates = this.safeGetStates(ownerKey);
+        this.assertStateExists(stateName, ownerStates, ownerKey);
+
+        return ownerStates[stateName];
+    }
+
+    public setStateValue(ownerKey: string, stateName: StateWatcherName, newValue: any) {
+        const ownerStates = this.safeGetStates(ownerKey);
+        this.assertStateExists(stateName, ownerStates, ownerKey);
+
+        ownerStates[stateName] = newValue;
+    }
+
+    private safeGetStates(ownerKey: string): Map<StateWatcherName, any> {
+        if (!Contract.assertTrue(this.watchedState.has(ownerKey), `State owner '${ownerKey}' not in '${Array.from(this.watchedState.keys()).join(', ')}'`)) {
+            return new Map();
+        }
+
+        return this.watchedState[ownerKey];
+    }
+
+    private assertStateExists(stateName: StateWatcherName, states: Map<StateWatcherName, any>, ownerKey: string) {
+        if (!Contract.assertTrue(states.has(stateName), `State name ${stateName} not found in state list for state owner '${ownerKey}': ${Array.from(states.keys()).join(', ')}`)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/server/game/core/stateWatcher/StateWatcherRegistrar.ts
+++ b/server/game/core/stateWatcher/StateWatcherRegistrar.ts
@@ -4,61 +4,58 @@ import Player from '../Player';
 import Contract from '../utils/Contract';
 
 export class StateWatcherRegistrar {
-    private watchedState = new Map<Player, Map<string, any>>();
+    private watchedState = new Map<string, any>();
 
     public constructor(public readonly game: Game) {
     }
 
-    public isRegistered(owner: Player, watcherKey: string) {
-        return this.watchedState.has(owner) && this.watchedState.get(owner).has(watcherKey);
+    public isRegistered(watcherKey: string) {
+        return this.watchedState.has(watcherKey);
     }
 
-    public register(owner: Player, watcherKey: string, initialValue: any, listeners: IStateListenerProperties<any>[]) {
-        if (this.isRegistered(owner, watcherKey)) {
+    public register(watcherKey: string, initialValue: any, listeners: IStateListenerProperties<any>[]) {
+        if (this.isRegistered(watcherKey)) {
             return;
         }
 
         // set the initial state value
-        this.setStateValue(owner, watcherKey, initialValue);
+        this.setStateValue(watcherKey, initialValue, true);
 
         for (const listener of listeners) {
             const eventNames = Object.keys(listener.when);
 
             // build a handler that will use the listener's update handler to generate a new state value and then store it
             const stateUpdateHandler = (event) => {
-                const currentStateValue = this.getStateValue(owner, watcherKey);
+                const currentStateValue = this.getStateValue(watcherKey);
                 const updatedStateValue = listener.update(currentStateValue, event);
-                this.setStateValue(owner, watcherKey, updatedStateValue);
+                this.setStateValue(watcherKey, updatedStateValue);
             };
 
             eventNames.forEach((eventName) => this.game.on(eventName, stateUpdateHandler));
         }
     }
 
-    public getStateValue(owner: Player, watcherKey: string): any {
-        const ownerStates = this.safeGetStates(owner);
-        this.assertStateExists(watcherKey, ownerStates, owner);
-
-        return ownerStates[watcherKey];
-    }
-
-    public setStateValue(owner: Player, watcherKey: string, newValue: any) {
-        const ownerStates = this.safeGetStates(owner);
-        this.assertStateExists(watcherKey, ownerStates, owner);
-
-        ownerStates.set(watcherKey, newValue);
-    }
-
-    private safeGetStates(owner: Player): Map<string, any> {
-        if (!Contract.assertTrue(this.watchedState.has(owner), `Player '${owner.name}' not in '${Array.from(this.watchedState.keys()).join(', ')}'`)) {
-            return new Map();
+    public getStateValue(watcherKey: string): any {
+        if (!this.assertRegistered(watcherKey)) {
+            return null;
         }
 
-        return this.watchedState.get(owner);
+        return this.watchedState.get(watcherKey);
     }
 
-    private assertStateExists(watcherKey: string, states: Map<string, any>, owner: Player) {
-        if (!Contract.assertTrue(states.has(watcherKey), `Watcher '${watcherKey}' not found in watcher list for '${owner.name}': ${Array.from(states.keys()).join(', ')}`)) {
+    public setStateValue(watcherKey: string, newValue: any, initializing: boolean = false) {
+        if (!initializing && !this.assertRegistered(watcherKey)) {
+            return;
+        }
+
+        this.watchedState.set(watcherKey, newValue);
+    }
+
+    private assertRegistered(watcherKey: string) {
+        if (
+            !Contract.assertTrue(this.isRegistered(watcherKey),
+                `Watcher '${watcherKey}' not found in registered watcher list: ${Array.from(this.watchedState.keys()).join(', ')}`)
+        ) {
             return false;
         }
 

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -28,7 +28,7 @@ export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveToken
         }
 
         for (let i = 0; i < properties.amount; i++) {
-            const tokenUpgrade = event.context.game.generateToken(event.context.source.controller, this.properties.tokenType);
+            const tokenUpgrade = event.context.game.generateToken(event.context.source.controller, properties.tokenType);
             tokenUpgrade.attachTo(cardReceivingTokenUpgrade);
         }
     }
@@ -43,6 +43,8 @@ export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveToken
     }
 
     public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
+        const properties = this.generatePropertiesFromContext(context);
+
         if (
             !Contract.assertNotNullLike(context) ||
             !Contract.assertNotNullLike(context.player) ||
@@ -51,9 +53,14 @@ export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveToken
             return false;
         }
 
-        if (!card.isUnit() || !EnumHelpers.isArena(card.location)) {
+        if (
+            !card.isUnit() ||
+            !EnumHelpers.isArena(card.location) ||
+            properties.amount === 0
+        ) {
             return false;
         }
+
         return super.canAffect(card, context);
     }
 

--- a/server/game/gameSystems/PutIntoPlaySystem.ts
+++ b/server/game/gameSystems/PutIntoPlaySystem.ts
@@ -24,7 +24,6 @@ export class PutIntoPlaySystem extends CardTargetSystem<IPutIntoPlayProperties> 
 
     public eventHandler(event, additionalProperties = {}): void {
         const player = this.getPutIntoPlayPlayer(event.context);
-        event.card.new = true;
 
         let finalController = event.context.player;
         if (event.controller === RelativePlayer.Opponent) {

--- a/server/game/stateWatchers/AttacksThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/AttacksThisPhaseWatcher.ts
@@ -32,6 +32,7 @@ export class AttacksThisPhaseWatcher extends StateWatcher<IAttacksThisPhase> {
         return super.getCurrentValue();
     }
 
+    /** Filters the list of attack events in the state and returns the attackers that match */
     public getAttackers(filter: (entry: AttackEntry) => boolean): Card[] {
         return this.getCurrentValue()
             .filter(filter)

--- a/server/game/stateWatchers/AttacksThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/AttacksThisPhaseWatcher.ts
@@ -1,10 +1,10 @@
-import { StateWatcher } from './StateWatcher';
-import { StateWatcherName } from '../Constants';
-import { StateWatcherRegistrar } from './StateWatcherRegistrar';
-import Player from '../Player';
-import { UnitCard } from '../card/CardTypes';
-import { Card } from '../card/Card';
-import { BaseCard } from '../card/BaseCard';
+import { StateWatcher } from '../core/stateWatcher/StateWatcher';
+import { StateWatcherName } from '../core/Constants';
+import { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
+import Player from '../core/Player';
+import { UnitCard } from '../core/card/CardTypes';
+import { Card } from '../core/card/Card';
+import { BaseCard } from '../core/card/BaseCard';
 
 export interface AttackEntry {
     attacker: UnitCard,

--- a/server/game/stateWatchers/AttacksThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/AttacksThisPhaseWatcher.ts
@@ -32,6 +32,12 @@ export class AttacksThisPhaseWatcher extends StateWatcher<IAttacksThisPhase> {
         return super.getCurrentValue();
     }
 
+    public getAttackers(filter: (entry: AttackEntry) => boolean): Card[] {
+        return this.getCurrentValue()
+            .filter(filter)
+            .map((entry) => entry.attacker);
+    }
+
     protected override setupWatcher() {
         this.addUpdater({
             when: {

--- a/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
@@ -13,7 +13,7 @@ export interface PlayedCardEntry {
 
 export type ICardsPlayedThisPhase = PlayedCardEntry[];
 
-export class CardsPlayedThisPhaseWatcher extends StateWatcher<ICardsPlayedThisPhase> {
+export class CardsPlayedThisPhaseWatcher extends StateWatcher<PlayedCardEntry[]> {
     public constructor(
         registrar: StateWatcherRegistrar,
         card: Card

--- a/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
@@ -29,6 +29,7 @@ export class CardsPlayedThisPhaseWatcher extends StateWatcher<PlayedCardEntry[]>
         return super.getCurrentValue();
     }
 
+    /** Filters the list of played cards in the state and returns the cards that match */
     public getCardsPlayed(filter: (entry: PlayedCardEntry) => boolean): Card[] {
         return this.getCurrentValue()
             .filter(filter)

--- a/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
@@ -29,6 +29,12 @@ export class CardsPlayedThisPhaseWatcher extends StateWatcher<PlayedCardEntry[]>
         return super.getCurrentValue();
     }
 
+    public getCardsPlayed(filter: (entry: PlayedCardEntry) => boolean): Card[] {
+        return this.getCurrentValue()
+            .filter(filter)
+            .map((entry) => entry.card);
+    }
+
     protected override setupWatcher() {
         // on card played, add the card to the player's list of cards played this phase
         this.addUpdater({

--- a/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
@@ -1,10 +1,10 @@
-import { StateWatcher } from './StateWatcher';
-import { StateWatcherName } from '../Constants';
-import { StateWatcherRegistrar } from './StateWatcherRegistrar';
-import Player from '../Player';
-import { PlayableCard } from '../card/CardTypes';
-import Game from '../Game';
-import { Card } from '../card/Card';
+import { StateWatcher } from '../core/stateWatcher/StateWatcher';
+import { StateWatcherName } from '../core/Constants';
+import { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
+import Player from '../core/Player';
+import { PlayableCard } from '../core/card/CardTypes';
+import Game from '../core/Game';
+import { Card } from '../core/card/Card';
 
 export interface PlayedCardEntry {
     card: PlayableCard,

--- a/server/game/stateWatchers/StateWatcherLibrary.ts
+++ b/server/game/stateWatchers/StateWatcherLibrary.ts
@@ -1,0 +1,9 @@
+import { Card } from '../core/card/Card';
+import { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
+import { AttacksThisPhaseWatcher } from './AttacksThisPhaseWatcher';
+import { CardsPlayedThisPhaseWatcher } from './CardsPlayedThisPhaseWatcher';
+
+export = {
+    attacksThisPhase: (registrar: StateWatcherRegistrar, card: Card) => new AttacksThisPhaseWatcher(registrar, card),
+    cardsPlayedThisPhase: (registrar: StateWatcherRegistrar, card: Card) => new CardsPlayedThisPhaseWatcher(registrar, card)
+};

--- a/test/helpers/GameFlowWrapper.js
+++ b/test/helpers/GameFlowWrapper.js
@@ -45,7 +45,13 @@ class GameFlowWrapper {
      * @param {Function} handler - function of a player to be executed
      */
     eachPlayerStartingWithPrompted(handler) {
-        var playersInPromptedOrder = this.allPlayers.sort((player) => player.hasPrompt('Waiting for opponent to take an action or pass'));
+        const playerPromptStateToSortOrder = (player) => {
+            return player.hasPrompt('Waiting for opponent to take an action or pass') ? 1 : 0;
+        };
+
+        var playersInPromptedOrder = this.allPlayers.sort((playerA, playerB) =>
+            playerPromptStateToSortOrder(playerA) - playerPromptStateToSortOrder(playerB)
+        );
         playersInPromptedOrder.forEach((player) => handler(player));
     }
 

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -491,6 +491,46 @@ var customMatchers = {
                 return result;
             }
         };
+    },
+    toHaveExactUpgradeNames: function () {
+        return {
+            compare: function (card, upgradeNames) {
+                let result = {};
+
+                if (!card.upgrades) {
+                    throw new Error(`Card ${card.internalName} does not have an upgrades property`);
+                }
+
+                const actualUpgradeNames = card.upgrades.map((upgrade) => upgrade.internalName);
+
+                const expectedUpgradeNames = [...upgradeNames];
+
+                let expectedUpgrades = expectedUpgradeNames.filter((x) => actualUpgradeNames.includes(x));
+                let missingUpgrades = expectedUpgradeNames.filter((x) => !actualUpgradeNames.includes(x));
+                let unexpectedUpgrades = actualUpgradeNames.filter((x) => !expectedUpgradeNames.includes(x));
+
+                result.pass = unexpectedUpgrades.length === 0 && missingUpgrades.length === 0;
+
+                if (result.pass) {
+                    result.message = `Expected ${card.internalName} not to have this exact set of upgrades but it does: ${expectedUpgrades.join(', ')}`;
+                } else {
+                    let message = '';
+
+                    if (missingUpgrades.length > 0) {
+                        message = `Expected ${card.internalName} to have the following upgrades but it does not: ${missingUpgrades.join(', ')}`;
+                    }
+                    if (unexpectedUpgrades.length > 0) {
+                        if (message.length > 0) {
+                            message += '\n';
+                        }
+                        message += `Expected ${card.internalName} not to have the following upgrades but it does: ${unexpectedUpgrades.join(', ')}`;
+                    }
+                    result.message = message;
+                }
+
+                return result;
+            }
+        };
     }
 };
 

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -527,28 +527,37 @@ class PlayerInteractionWrapper {
 
     getPlayerPromptState() {
         return {
-            actionTargets: this.player.promptState.selectableCards,
+            selectableCards: this.copySelectionArray(this.player.promptState.selectableCards),
+            selectedCards: this.copySelectionArray(this.player.promptState.selectedCards),
             menuTitle: this.player.currentPrompt().menuTitle,
             promptTitle: this.player.currentPrompt().promptTitle
         };
+    }
+
+    copySelectionArray(ara) {
+        return ara == null ? [] : [...ara];
     }
 
     promptStatesEqual(promptState1, promptState2) {
         if (
             promptState1.menuTitle !== promptState2.menuTitle ||
             promptState1.promptTitle !== promptState2.promptTitle ||
-            promptState1.actionTargets.length !== promptState2.actionTargets.length
+            promptState1.selectableCards.length !== promptState2.selectableCards.length ||
+            promptState1.selectedCards.length !== promptState2.selectedCards.length
         ) {
             return false;
         }
 
-        const targets1 = promptState1.actionTargets;
-        const targets2 = promptState2.actionTargets;
-        targets1.sort();
-        targets2.sort();
+        return this.selectionArraysEqual(promptState1.selectedCards, promptState2.selectedCards) &&
+            this.selectionArraysEqual(promptState1.selectableCards, promptState2.selectableCards);
+    }
 
-        for (let i = 0; i < targets1.length; i++) {
-            if (targets1[i] !== targets2[i]) {
+    selectionArraysEqual(ara1, ara2) {
+        ara1.sort();
+        ara2.sort();
+
+        for (let i = 0; i < ara1.length; i++) {
+            if (ara1[i] !== ara2[i]) {
                 return false;
             }
         }

--- a/test/server/cards/01_SOR/GrandMoffTarkinOversectorGovernor.spec.js
+++ b/test/server/cards/01_SOR/GrandMoffTarkinOversectorGovernor.spec.js
@@ -54,8 +54,7 @@ describe('Grand Moff Tarkin, Oversector Governor', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tielnFighter]);
                 this.player1.clickCard(this.tielnFighter);
 
-                expect(this.tielnFighter.upgrades.length).toBe(1);
-                expect(this.tielnFighter.upgrades[0].internalName).toBe('experience');
+                expect(this.tielnFighter).toHaveExactUpgradeNames(['experience']);
                 expect(this.grandMoffTarkin.damage).toBe(4);
                 expect(this.wampa.damage).toBe(2);
             });

--- a/test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
+++ b/test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
@@ -1,0 +1,66 @@
+describe('Luke Skywalker, Faithful Friend', function() {
+    integration(function() {
+        describe('Luke\'s undeployed ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['battlefield-marine', 'cartel-spacer'],
+                        groundArena: ['atst'],
+                        leader: 'luke-skywalker#faithful-friend'
+                    },
+                    player2: {
+                        hand: ['alliance-dispatcher'],
+                        groundArena: ['specforce-soldier'],
+                    }
+                });
+            });
+
+            it('should give a friendly heroism unit played by us this turn a shield token', function () {
+                this.player1.clickCard(this.battlefieldMarine);
+
+                this.player2.clickCard(this.allianceDispatcher);
+
+                this.player1.clickCard(this.cartelSpacer);
+
+                this.player2.passAction();
+
+                this.player1.clickCard(this.lukeSkywalker);
+                this.player1.clickPrompt('Give a shield to a heroism unit you played this phase');
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames(['shield']);
+            });
+        });
+
+        // describe('Luke\'s deployed ability', function() {
+        //     beforeEach(function () {
+        //         this.setupTest({
+        //             phase: 'action',
+        //             player1: {
+        //                 groundArena: ['atst', 'battlefield-marine'],
+        //                 spaceArena: ['tieln-fighter'],
+        //                 leader: { card: 'grand-moff-tarkin#oversector-governor', deployed: true }
+        //             },
+        //             player2: {
+        //                 groundArena: ['wampa'],
+        //                 spaceArena: ['tie-advanced']
+        //             }
+        //         });
+        //     });
+
+        //     it('should give a friendly imperial unit an experience token on attack', function () {
+        //         this.player1.clickCard(this.grandMoffTarkin);
+        //         this.player1.clickCard(this.wampa);
+
+        //         expect(this.player1).toHavePrompt('Choose a card');
+        //         expect(this.player1).toHaveEnabledPromptButton('Pass ability');
+        //         expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tielnFighter]);
+        //         this.player1.clickCard(this.tielnFighter);
+
+        //         expect(this.tielnFighter.upgrades.length).toBe(1);
+        //         expect(this.tielnFighter.upgrades[0].internalName).toBe('experience');
+        //         expect(this.grandMoffTarkin.damage).toBe(4);
+        //         expect(this.wampa.damage).toBe(2);
+        //     });
+        // });
+    });
+});

--- a/test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
+++ b/test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
@@ -5,7 +5,7 @@ describe('Luke Skywalker, Faithful Friend', function() {
                 this.setupTest({
                     phase: 'action',
                     player1: {
-                        hand: ['battlefield-marine', 'cartel-spacer'],
+                        hand: ['battlefield-marine', 'cartel-spacer', 'alliance-xwing'],
                         groundArena: ['atst'],
                         leader: 'luke-skywalker#faithful-friend'
                     },
@@ -25,9 +25,29 @@ describe('Luke Skywalker, Faithful Friend', function() {
 
                 this.player2.passAction();
 
+                const resourcesSpentBeforeLukeActivation = this.player1.countExhaustedResources();
                 this.player1.clickCard(this.lukeSkywalker);
                 this.player1.clickPrompt('Give a shield to a heroism unit you played this phase');
                 expect(this.battlefieldMarine).toHaveExactUpgradeNames(['shield']);
+                expect(this.lukeSkywalker.exhausted).toBe(true);
+                expect(this.player1.countExhaustedResources()).toBe(resourcesSpentBeforeLukeActivation + 1);
+            });
+
+            it('should not be able to give a shield to a unit played in the previous phase', function () {
+                this.player1.clickCard(this.battlefieldMarine);
+
+                this.moveToNextActionPhase();
+
+                this.player1.clickCard(this.allianceXwing);
+
+                this.player2.passAction();
+
+                const resourcesSpentBeforeLukeActivation = this.player1.countExhaustedResources();
+                this.player1.clickCard(this.lukeSkywalker);
+                this.player1.clickPrompt('Give a shield to a heroism unit you played this phase');
+                expect(this.allianceXwing).toHaveExactUpgradeNames(['shield']);
+                expect(this.lukeSkywalker.exhausted).toBe(true);
+                expect(this.player1.countExhaustedResources()).toBe(resourcesSpentBeforeLukeActivation + 1);
             });
         });
 

--- a/test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
+++ b/test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
@@ -51,36 +51,49 @@ describe('Luke Skywalker, Faithful Friend', function() {
             });
         });
 
-        // describe('Luke\'s deployed ability', function() {
-        //     beforeEach(function () {
-        //         this.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 groundArena: ['atst', 'battlefield-marine'],
-        //                 spaceArena: ['tieln-fighter'],
-        //                 leader: { card: 'grand-moff-tarkin#oversector-governor', deployed: true }
-        //             },
-        //             player2: {
-        //                 groundArena: ['wampa'],
-        //                 spaceArena: ['tie-advanced']
-        //             }
-        //         });
-        //     });
+        describe('Luke\'s deployed ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['atst'],
+                        spaceArena: ['tieln-fighter'],
+                        leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['tie-advanced']
+                    }
+                });
+            });
 
-        //     it('should give a friendly imperial unit an experience token on attack', function () {
-        //         this.player1.clickCard(this.grandMoffTarkin);
-        //         this.player1.clickCard(this.wampa);
+            it('should give any unit a shield token on attack', function () {
+                this.player1.clickCard(this.lukeSkywalker);
+                this.player1.clickCard(this.wampa);
 
-        //         expect(this.player1).toHavePrompt('Choose a card');
-        //         expect(this.player1).toHaveEnabledPromptButton('Pass ability');
-        //         expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tielnFighter]);
-        //         this.player1.clickCard(this.tielnFighter);
+                expect(this.player1).toHavePrompt('Choose a card');
+                expect(this.player1).toHaveEnabledPromptButton('Pass ability');
+                expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tielnFighter, this.wampa, this.tieAdvanced]);
+                this.player1.clickCard(this.tielnFighter);
 
-        //         expect(this.tielnFighter.upgrades.length).toBe(1);
-        //         expect(this.tielnFighter.upgrades[0].internalName).toBe('experience');
-        //         expect(this.grandMoffTarkin.damage).toBe(4);
-        //         expect(this.wampa.damage).toBe(2);
-        //     });
-        // });
+                expect(this.tielnFighter).toHaveExactUpgradeNames(['shield']);
+                expect(this.lukeSkywalker.damage).toBe(4);
+                expect(this.wampa.damage).toBe(4);
+
+                // reset for a second attack to confirm that shield gets applied to wampa before the attack damage happens
+                this.lukeSkywalker.damage = 0;
+                this.lukeSkywalker.exhausted = false;
+                this.wampa.damage = 0;
+                this.player2.passAction();
+
+                this.player1.clickCard(this.lukeSkywalker);
+                this.player1.clickCard(this.wampa);
+                this.player1.clickCard(this.wampa);
+
+                expect(this.lukeSkywalker.damage).toBe(4);
+                expect(this.wampa.damage).toBe(0);
+                expect(this.wampa.upgrades.length).toBe(0);
+            });
+        });
     });
 });

--- a/test/server/cards/01_SOR/MedalCeremony.spec.js
+++ b/test/server/cards/01_SOR/MedalCeremony.spec.js
@@ -56,8 +56,10 @@ describe('Medal Ceremony', function() {
                 this.player1.clickCard(this.battlefieldMarine);
                 this.player1.clickCard(this.rebelPathfinder);
                 this.player1.clickCard(this.allianceXwing);
+
                 // click on a fourth card just to confirm it doesn't work
-                this.player1.clickCard(this.consularSecurityForce);
+                this.player1.clickCardNonChecking(this.consularSecurityForce);
+
                 this.player1.clickPrompt('Done');
                 expect(this.battlefieldMarine).toHaveExactUpgradeNames(['experience']);
                 expect(this.rebelPathfinder).toHaveExactUpgradeNames(['experience']);

--- a/test/server/cards/01_SOR/MedalCeremony.spec.js
+++ b/test/server/cards/01_SOR/MedalCeremony.spec.js
@@ -1,0 +1,58 @@
+describe('Medal Ceremony', function() {
+    integration(function() {
+        describe('Medal Ceremony\'s ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['medal-ceremony'],
+                        groundArena: ['battlefield-marine', 'frontier-atrt', 'alliance-dispatcher', 'rebel-pathfinder'],
+                        // leader: { card: 'chirrut-imwe#one-with-the-force', deployed: true } // TODO: merge leader PR
+                    },
+                    player2: {
+                        groundArena: ['wampa', 'consular-security-force'],
+                        spaceArena: ['alliance-xwing']
+                    }
+                });
+            });
+
+            it('should give an experience to any Rebel units that attacked this phase, up to 3', function () {
+                // attack 1: our rebel
+                this.player1.clickCard(this.battlefieldMarine);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 2: their non-rebel
+                this.player2.clickCard(this.wampa);
+                this.player2.clickCard(this.p1Base);
+
+                // // attack 3: our rebel (leader)
+                // this.player1.clickCard(this.chirrutImwe);
+                // this.player1.clickCard(this.wampa);
+
+                // attack 3: our rebel
+                this.player1.clickCard(this.rebelPathfinder);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 4: their rebel
+                this.player2.clickCard(this.consularSecurityForce);
+                this.player2.clickCard(this.p1Base);
+
+                // attack 5: our non-rebel
+                this.player1.clickCard(this.frontierAtrt);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 6: their rebel
+                this.player2.clickCard(this.allianceXwing);
+
+                // attack 7: our rebel (goes to discard)
+                this.player1.clickCard(this.allianceDispatcher);
+                this.player1.clickCard(this.wampa);
+
+                this.player2.passAction();
+
+                this.player1.clickCard(this.medalCeremony);
+                expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.rebelPathfinder, this.consularSecurityForce, this.allianceXwing]);
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/MedalCeremony.spec.js
+++ b/test/server/cards/01_SOR/MedalCeremony.spec.js
@@ -56,10 +56,13 @@ describe('Medal Ceremony', function() {
                 this.player1.clickCard(this.battlefieldMarine);
                 this.player1.clickCard(this.rebelPathfinder);
                 this.player1.clickCard(this.allianceXwing);
+                // click on a fourth card just to confirm it doesn't work
+                this.player1.clickCard(this.consularSecurityForce);
                 this.player1.clickPrompt('Done');
                 expect(this.battlefieldMarine).toHaveExactUpgradeNames(['experience']);
                 expect(this.rebelPathfinder).toHaveExactUpgradeNames(['experience']);
                 expect(this.allianceXwing).toHaveExactUpgradeNames(['experience']);
+                expect(this.consularSecurityForce.upgrades.length).toBe(0);
             });
         });
     });

--- a/test/server/cards/01_SOR/MedalCeremony.spec.js
+++ b/test/server/cards/01_SOR/MedalCeremony.spec.js
@@ -6,8 +6,8 @@ describe('Medal Ceremony', function() {
                     phase: 'action',
                     player1: {
                         hand: ['medal-ceremony'],
-                        groundArena: ['battlefield-marine', 'frontier-atrt', 'alliance-dispatcher', 'rebel-pathfinder'],
-                        // leader: { card: 'chirrut-imwe#one-with-the-force', deployed: true } // TODO: merge leader PR
+                        groundArena: ['battlefield-marine', 'frontier-atrt', 'alliance-dispatcher'],
+                        leader: { card: 'chirrut-imwe#one-with-the-force', deployed: true }
                     },
                     player2: {
                         groundArena: ['wampa', 'consular-security-force'],
@@ -25,13 +25,9 @@ describe('Medal Ceremony', function() {
                 this.player2.clickCard(this.wampa);
                 this.player2.clickCard(this.p1Base);
 
-                // // attack 3: our rebel (leader)
-                // this.player1.clickCard(this.chirrutImwe);
-                // this.player1.clickCard(this.wampa);
-
-                // attack 3: our rebel
-                this.player1.clickCard(this.rebelPathfinder);
-                this.player1.clickCard(this.p2Base);
+                // attack 3: our rebel (leader)
+                this.player1.clickCard(this.chirrutImwe);
+                this.player1.clickCard(this.wampa);
 
                 // attack 4: their rebel
                 this.player2.clickCard(this.consularSecurityForce);
@@ -51,10 +47,10 @@ describe('Medal Ceremony', function() {
                 this.player2.passAction();
 
                 this.player1.clickCard(this.medalCeremony);
-                expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.rebelPathfinder, this.consularSecurityForce, this.allianceXwing]);
+                expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.chirrutImwe, this.consularSecurityForce, this.allianceXwing]);
 
                 this.player1.clickCard(this.battlefieldMarine);
-                this.player1.clickCard(this.rebelPathfinder);
+                this.player1.clickCard(this.chirrutImwe);
                 this.player1.clickCard(this.allianceXwing);
 
                 // click on a fourth card just to confirm it doesn't work
@@ -62,9 +58,90 @@ describe('Medal Ceremony', function() {
 
                 this.player1.clickPrompt('Done');
                 expect(this.battlefieldMarine).toHaveExactUpgradeNames(['experience']);
-                expect(this.rebelPathfinder).toHaveExactUpgradeNames(['experience']);
+                expect(this.chirrutImwe).toHaveExactUpgradeNames(['experience']);
                 expect(this.allianceXwing).toHaveExactUpgradeNames(['experience']);
                 expect(this.consularSecurityForce.upgrades.length).toBe(0);
+            });
+
+            it('should give only as many experience tokens as available Rebel units that have attacked', function () {
+                // attack 1: our rebel
+                this.player1.clickCard(this.battlefieldMarine);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 2: their non-rebel
+                this.player2.clickCard(this.wampa);
+                this.player2.clickCard(this.p1Base);
+
+                // attack 3: our non-rebel
+                this.player1.clickCard(this.frontierAtrt);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 4: their rebel
+                this.player2.clickCard(this.consularSecurityForce);
+                this.player2.clickCard(this.p1Base);
+
+                this.player1.clickCard(this.medalCeremony);
+                expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.consularSecurityForce]);
+
+                this.player1.clickCard(this.battlefieldMarine);
+                this.player1.clickCard(this.consularSecurityForce);
+
+                this.player1.clickPrompt('Done');
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames(['experience']);
+                expect(this.consularSecurityForce).toHaveExactUpgradeNames(['experience']);
+            });
+
+            it('should allow selecting fewer targets than available', function () {
+                // attack 1: our rebel
+                this.player1.clickCard(this.battlefieldMarine);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 2: their non-rebel
+                this.player2.clickCard(this.wampa);
+                this.player2.clickCard(this.p1Base);
+
+                // attack 3: our non-rebel
+                this.player1.clickCard(this.frontierAtrt);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 4: their rebel
+                this.player2.clickCard(this.consularSecurityForce);
+                this.player2.clickCard(this.p1Base);
+
+                this.player1.clickCard(this.medalCeremony);
+                expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.consularSecurityForce]);
+
+                this.player1.clickCard(this.battlefieldMarine);
+
+                this.player1.clickPrompt('Done');
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames(['experience']);
+                expect(this.consularSecurityForce.upgrades.length).toBe(0);
+            });
+
+            it('should allow selecting no targets', function () {
+                // attack 1: our rebel
+                this.player1.clickCard(this.battlefieldMarine);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 2: their non-rebel
+                this.player2.clickCard(this.wampa);
+                this.player2.clickCard(this.p1Base);
+
+                // attack 3: our non-rebel
+                this.player1.clickCard(this.frontierAtrt);
+                this.player1.clickCard(this.p2Base);
+
+                // attack 4: their rebel
+                this.player2.clickCard(this.consularSecurityForce);
+                this.player2.clickCard(this.p1Base);
+
+                this.player1.clickCard(this.medalCeremony);
+                expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.consularSecurityForce]);
+
+                this.player1.clickPrompt('Done');
+                expect(this.consularSecurityForce.upgrades.length).toBe(0);
+                expect(this.consularSecurityForce.upgrades.length).toBe(0);
+                expect(this.player2).toBeActivePlayer();
             });
         });
     });

--- a/test/server/cards/01_SOR/MedalCeremony.spec.js
+++ b/test/server/cards/01_SOR/MedalCeremony.spec.js
@@ -52,6 +52,14 @@ describe('Medal Ceremony', function() {
 
                 this.player1.clickCard(this.medalCeremony);
                 expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.rebelPathfinder, this.consularSecurityForce, this.allianceXwing]);
+
+                this.player1.clickCard(this.battlefieldMarine);
+                this.player1.clickCard(this.rebelPathfinder);
+                this.player1.clickCard(this.allianceXwing);
+                this.player1.clickPrompt('Done');
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames(['experience']);
+                expect(this.rebelPathfinder).toHaveExactUpgradeNames(['experience']);
+                expect(this.allianceXwing).toHaveExactUpgradeNames(['experience']);
             });
         });
     });

--- a/test/server/cards/01_SOR/MomentOfPeace.spec.js
+++ b/test/server/cards/01_SOR/MomentOfPeace.spec.js
@@ -19,7 +19,7 @@ describe('Moment of Peace', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.cartelSpacer]);
 
                 this.player1.clickCard(this.wampa);
-                expect(this.wampa.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['shield']);
+                expect(this.wampa).toHaveExactUpgradeNames(['shield']);
             });
 
             it('can give a shield to a unit that already has a shield', function () {
@@ -27,7 +27,7 @@ describe('Moment of Peace', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.cartelSpacer]);
 
                 this.player1.clickCard(this.cartelSpacer);
-                expect(this.cartelSpacer.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['shield', 'shield']);
+                expect(this.cartelSpacer).toHaveExactUpgradeNames(['shield', 'shield']);
             });
         });
     });

--- a/test/server/cards/01_SOR/TieAdvanced.spec.js
+++ b/test/server/cards/01_SOR/TieAdvanced.spec.js
@@ -19,7 +19,7 @@ describe('Tie Avanced', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tielnFighter]);
                 this.player1.clickCard(this.atst);
 
-                expect(this.atst.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience']);
+                expect(this.atst).toHaveExactUpgradeNames(['experience', 'experience']);
             });
 
             it('can give two experience to a unit that already has an experience', function () {
@@ -27,7 +27,7 @@ describe('Tie Avanced', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.atst, this.tielnFighter]);
                 this.player1.clickCard(this.tielnFighter);
 
-                expect(this.tielnFighter.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience', 'experience']);
+                expect(this.tielnFighter).toHaveExactUpgradeNames(['experience', 'experience', 'experience']);
             });
         });
     });

--- a/test/server/cards/01_SOR/VanguardAce.spec.js
+++ b/test/server/cards/01_SOR/VanguardAce.spec.js
@@ -29,7 +29,7 @@ describe('Vanguard Ace', function() {
                 this.player2.passAction();
 
                 this.player1.clickCard(this.vanguardAce);
-                expect(this.vanguardAce.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience', 'experience']);
+                expect(this.vanguardAce).toHaveExactUpgradeNames(['experience', 'experience', 'experience']);
             });
 
             it('gains no experience if no other cards have been played', function () {
@@ -51,7 +51,7 @@ describe('Vanguard Ace', function() {
                 this.player2.clickCard(this.atst);
 
                 this.player1.clickCard(this.vanguardAce);
-                expect(this.vanguardAce.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience']);
+                expect(this.vanguardAce).toHaveExactUpgradeNames(['experience']);
             });
 
             // TODO TAKE CONTROL: check that state watchers still work if the card is played by the opponent

--- a/test/server/cards/01_SOR/VanguardAce.spec.js
+++ b/test/server/cards/01_SOR/VanguardAce.spec.js
@@ -1,0 +1,33 @@
+describe('Vanguard Ace', function() {
+    integration(function() {
+        describe('Vanguard Ace\'s ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['vanguard-ace', 'daring-raid', 'battlefield-marine'],
+                    },
+                    player2: {
+                        hand: ['wampa', 'atst']
+                    }
+                });
+            });
+
+            it('gains 1 experience for each card played by the controller this phase', function () {
+                this.player1.clickCard(this.daringRaid);
+                this.player1.clickCard(this.p2Base);
+
+                this.player2.clickCard(this.wampa);
+
+                this.player1.clickCard(this.battlefieldMarine);
+
+                this.player2.clickCard(this.atst);
+
+                this.player1.clickCard(this.vanguardAce);
+                expect(this.vanguardAce.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience']);
+            });
+
+            // TODO TAKE CONTROL: check that state watchers still work if the card is played by the opponent
+        });
+    });
+});

--- a/test/server/cards/01_SOR/VanguardAce.spec.js
+++ b/test/server/cards/01_SOR/VanguardAce.spec.js
@@ -5,7 +5,7 @@ describe('Vanguard Ace', function() {
                 this.setupTest({
                     phase: 'action',
                     player1: {
-                        hand: ['vanguard-ace', 'daring-raid', 'battlefield-marine'],
+                        hand: ['vanguard-ace', 'daring-raid', 'battlefield-marine', 'academy-training', 'frontier-atrt'],
                     },
                     player2: {
                         hand: ['wampa', 'atst']
@@ -13,7 +13,7 @@ describe('Vanguard Ace', function() {
                 });
             });
 
-            it('gains 1 experience for each card played by the controller this phase', function () {
+            it('gains 1 experience for each other card played by the controller this phase', function () {
                 this.player1.clickCard(this.daringRaid);
                 this.player1.clickCard(this.p2Base);
 
@@ -23,8 +23,35 @@ describe('Vanguard Ace', function() {
 
                 this.player2.clickCard(this.atst);
 
+                this.player1.clickCard(this.academyTraining);
+                this.player1.clickCard(this.battlefieldMarine);
+
+                this.player2.passAction();
+
                 this.player1.clickCard(this.vanguardAce);
-                expect(this.vanguardAce.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience']);
+                expect(this.vanguardAce.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience', 'experience', 'experience']);
+            });
+
+            it('gains no experience if no other cards have been played', function () {
+                this.player1.clickCard(this.vanguardAce);
+                expect(this.vanguardAce.upgrades.length).toBe(0);
+            });
+
+            it('does not count cards played in the previous phase', function () {
+                this.player1.clickCard(this.daringRaid);
+                this.player1.clickCard(this.p2Base);
+
+                this.player2.passAction();
+
+                // TODO: fix this
+                this.moveToNextActionPhase();
+
+                this.player1.clickCard(this.battlefieldMarine);
+
+                this.player2.clickCard(this.atst);
+
+                this.player1.clickCard(this.vanguardAce);
+                expect(this.vanguardAce.upgrades.map((upgrade) => upgrade.internalName)).toEqual(['experience']);
             });
 
             // TODO TAKE CONTROL: check that state watchers still work if the card is played by the opponent

--- a/test/server/core/card/Leader.spec.js
+++ b/test/server/core/card/Leader.spec.js
@@ -111,13 +111,18 @@ describe('Leader cards', function() {
                 this.p2Base = this.player2.base;
             });
 
-            it('should have functioning keywords', function () {
+            it('should have functioning keywords and be exhausted on attack', function () {
                 this.p1Base.damage = 5;
                 this.player1.clickCard(this.directorKrennic);
                 this.player1.clickCard(this.player2.base);
 
                 expect(this.p1Base.damage).toBe(3);
                 expect(this.p2Base.damage).toBe(2);
+                expect(this.directorKrennic.exhausted).toBe(true);
+
+                this.player2.passAction();
+
+                expect(this.directorKrennic).not.toHaveAvailableActionWhenClickedInActionPhaseBy(this.player1);
             });
         });
     });


### PR DESCRIPTION
Added the concept of state watchers to address the needs of cards that refer back to events that have happened previously in the phase. For now, not making a distinction between "this round" and "this phase" since there is currently no game situation in which the distinction is important.

Added the Luke leader, Medal Ceremony, and Vanguard Ace as examples. Also did some light improvement and bug fixes to the test infra.