### PR TITLE
Refactor `generateEventsForAllTargets` to `queueGenerateEventGameSteps`

### DIFF
--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -921,7 +921,7 @@ class Game extends EventEmitter {
     //         const gameActionFactory = GameSystems[action];
     //         if (typeof gameActionFactory === 'function') {
     //             const gameSystem = gameActionFactory({ target: cards });
-    //             array.push(...gameSystem.generateEventsForAllTargets(context));
+    //             array.push(...gameSystem.queueGenerateEventGameSteps(context));
     //         }
     //         return array;
     //     }, []);

--- a/server/game/core/ability/CardAbilityStep.js
+++ b/server/game/core/ability/CardAbilityStep.js
@@ -85,9 +85,9 @@ class CardAbilityStep extends PlayerOrCardAbility {
         }
         for (const system of systems) {
             this.game.queueSimpleStep(() => {
-                context.events.push(...system.generateEventsForAllTargets(context));
+                system.queueGenerateEventGameSteps(context.events, context);
             },
-            `push ${system.name} events for ${this}`);
+            `queue ${system.name} event generation steps for ${this}`);
         }
         this.game.queueSimpleStep(() => {
             let eventsToResolve = context.events.filter((event) => !event.cancelled && !event.resolved);

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -149,8 +149,8 @@ class PlayerOrCardAbility {
         for (let cost of this.getCosts(context, results.playCosts, results.triggerCosts)) {
             context.game.queueSimpleStep(() => {
                 if (!results.cancelled) {
-                    if (cost.generateEventsForAllTargets) {
-                        results.events.push(...cost.generateEventsForAllTargets(context, results));
+                    if (cost.queueGenerateEventGameSteps) {
+                        cost.queueGenerateEventGameSteps(results.events, context, results);
                     } else {
                         if (cost.resolve) {
                             cost.resolve(context, results);

--- a/server/game/core/cost/GameActionCost.ts
+++ b/server/game/core/cost/GameActionCost.ts
@@ -6,6 +6,7 @@ import type { GameEvent } from '../event/GameEvent';
 /**
  * Class that wraps a {@link GameSystem} so it can be represented as an action cost
  */
+// TODO THIS PR: rename this to GameSystemAsCost
 export class GameActionCost implements ICost {
     public constructor(public gameSystem: GameSystem) {}
 
@@ -23,9 +24,9 @@ export class GameActionCost implements ICost {
         return this.gameSystem.hasLegalTarget(context);
     }
 
-    public generateEventsForAllTargets(context: AbilityContext, result: Result): GameEvent[] {
+    public queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, result: Result): void {
         context.costs[this.gameSystem.name] = this.gameSystem.generatePropertiesFromContext(context).target;
-        return this.gameSystem.generateEventsForAllTargets(context);
+        this.gameSystem.queueGenerateEventGameSteps(events, context);
     }
 
     public getCostMessage(context: AbilityContext): [string, any[]] {

--- a/server/game/core/cost/GameSystemCost.ts
+++ b/server/game/core/cost/GameSystemCost.ts
@@ -6,8 +6,7 @@ import type { GameEvent } from '../event/GameEvent';
 /**
  * Class that wraps a {@link GameSystem} so it can be represented as an action cost
  */
-// TODO THIS PR: rename this to GameSystemAsCost
-export class GameActionCost implements ICost {
+export class GameSystemCost implements ICost {
     public constructor(public gameSystem: GameSystem) {}
 
     public getActionName(context: AbilityContext): string {

--- a/server/game/core/cost/ICost.ts
+++ b/server/game/core/cost/ICost.ts
@@ -25,7 +25,7 @@ export interface ICost {
     getActionName?(context: AbilityContext): string;
     getCostMessage?(context: AbilityContext): unknown[];
     hasTargetsChosenByInitiatingPlayer?(context: AbilityContext): boolean;
-    generateEventsForAllTargets?(context: AbilityContext, result?: Result): GameEvent[];
+    queueGenerateEventGameSteps?(events: GameEvent[], context: AbilityContext, result?: Result): void;
     resolve?(context: AbilityContext, result: Result): void;
     payEvent?(context: TriggeredAbilityContext): GameEvent | GameEvent[];
     pay?(context: TriggeredAbilityContext): void;

--- a/server/game/core/cost/MetaActionCost.ts
+++ b/server/game/core/cost/MetaActionCost.ts
@@ -29,7 +29,7 @@ export class MetaActionCost extends GameActionCost implements ICost {
         return this.gameSystem.hasLegalTarget(context, additionalProps);
     }
 
-    public override generateEventsForAllTargets(context: AbilityContext, result: Result): GameEvent[] {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, result: Result): void {
         const properties = this.gameSystem.generatePropertiesFromContext(context) as ISelectCardProperties;
         if (properties.targets && context.choosingPlayerOverride) {
             context.costs[properties.innerSystem.name] = randomItem(
@@ -37,7 +37,7 @@ export class MetaActionCost extends GameActionCost implements ICost {
             );
             context.costs[properties.innerSystem.name + 'StateWhenChosen'] =
                 context.costs[properties.innerSystem.name].createSnapshot();
-            return properties.innerSystem.generateEventsForAllTargets(context, {
+            properties.innerSystem.queueGenerateEventGameSteps(events, context, {
                 target: context.costs[properties.innerSystem.name]
             });
         }
@@ -55,7 +55,7 @@ export class MetaActionCost extends GameActionCost implements ICost {
                 return properties.innerSystemProperties ? properties.innerSystemProperties(target) : {};
             }
         };
-        return this.gameSystem.generateEventsForAllTargets(context, additionalProps);
+        this.gameSystem.queueGenerateEventGameSteps(events, context, additionalProps);
     }
 
     public hasTargetsChosenByInitiatingPlayer(context: AbilityContext): boolean {

--- a/server/game/core/cost/MetaActionCost.ts
+++ b/server/game/core/cost/MetaActionCost.ts
@@ -4,10 +4,10 @@ import type { ICost, Result } from './ICost';
 import type { GameSystem } from '../gameSystem/GameSystem';
 import type { ISelectCardProperties } from '../../gameSystems/SelectCardSystem';
 import { randomItem } from '../utils/Helpers';
-import { GameActionCost } from './GameActionCost';
+import { GameSystemCost } from './GameSystemCost';
 import { GameEvent } from '../event/GameEvent';
 
-export class MetaActionCost extends GameActionCost implements ICost {
+export class MetaActionCost extends GameSystemCost implements ICost {
     public constructor(
         gameSystem: GameSystem,
         public activePromptTitle: string

--- a/server/game/core/gameSteps/phases/RegroupPhase.ts
+++ b/server/game/core/gameSteps/phases/RegroupPhase.ts
@@ -8,6 +8,7 @@ import { SimpleStep } from '../SimpleStep';
 import { VariableResourcePrompt } from '../prompts/VariableResourcePrompt';
 import { CardWithExhaustProperty } from '../../card/CardTypes';
 import { GameEvent } from '../../event/GameEvent';
+import * as GameSystemLibrary from '../../../gameSystems/GameSystemLibrary';
 
 export class RegroupPhase extends Phase {
     public constructor(game: Game) {
@@ -39,11 +40,10 @@ export class RegroupPhase extends Phase {
         }
 
         // create a single event for the ready cards step as well as individual events for readying each card
-        let events = [new GameEvent(EventName.OnRegroupPhaseReadyCards, {})];
-        events = events.concat(
-            this.game.actions.ready({ isRegroupPhaseReadyStep: true, target: cardsToReady })
-                .generateEventsForAllTargets(this.game.getFrameworkContext()));
+        const events = [new GameEvent(EventName.OnRegroupPhaseReadyCards, {})];
+        GameSystemLibrary.ready({ isRegroupPhaseReadyStep: true, target: cardsToReady })
+            .queueGenerateEventGameSteps(events, this.game.getFrameworkContext());
 
-        this.game.openEventWindow(events);
+        this.game.queueSimpleStep(() => this.game.openEventWindow(events), 'open event window for card readying effects');
     }
 }

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -29,9 +29,7 @@ export abstract class CardTargetSystem<TProperties extends ICardTargetSystemProp
         return EnumHelpers.cardTypeMatches((target as Card).type, this.targetTypeFilter);
     }
 
-    public override generateEventsForAllTargets(context: AbilityContext, additionalProperties = {}): GameEvent[] {
-        const events: GameEvent[] = [];
-
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
         const { target } = this.generatePropertiesFromContext(context, additionalProperties);
         for (const card of target as Card[]) {
             let allCostsPaid = true;
@@ -120,8 +118,6 @@ export abstract class CardTargetSystem<TProperties extends ICardTargetSystemProp
                 }
             }
         }
-
-        return events;
     }
 
     public override checkEventCondition(event: any, additionalProperties = {}): boolean {

--- a/server/game/core/gameSystem/GameSystem.ts
+++ b/server/game/core/gameSystem/GameSystem.ts
@@ -148,24 +148,22 @@ export abstract class GameSystem<TProperties extends IGameSystemProperties = IGa
     /**
      * Generates a list of {@link GameEvent} objects that will apply the effects of this system to the game state
      * by generating one event per target in `context.targets`.
-     * The events must be emitted using an {@link EventWindow}, typically via {@link Game.openEventWindow}.
+     * The events must be emitted using an {@link EventWindow}, typically via `Game.openEventWindow`.
      * @param context Context of ability being executed
      * @param additionalProperties Any additional properties to extend the default ones with
      */
-    public generateEventsForAllTargets(context: AbilityContext, additionalProperties = {}): GameEvent[] {
-        const events: GameEvent[] = [];
+    public queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
         for (const target of this.targets(context, additionalProperties)) {
             if (this.canAffect(target, context, additionalProperties)) {
                 events.push(this.generateEvent(target, context, additionalProperties));
             }
         }
-        return events;
     }
 
     /**
      * Generates one {@link GameEvent} object that will apply the effects of this system to the game state
      * for the specified target.
-     * The event must be emitted using an {@link EventWindow}, typically via {@link Game.openEventWindow}.
+     * The event must be emitted using an {@link EventWindow}, typically via `Game.openEventWindow`.
      * @param target Target to apply the system's effects to
      * @param context Context of ability being executed
      * @param additionalProperties Any additional properties to extend the default ones with
@@ -195,7 +193,9 @@ export abstract class GameSystem<TProperties extends IGameSystemProperties = IGa
         if (target) {
             this.setDefaultTargetFn(() => target);
         }
-        const events = this.generateEventsForAllTargets(context);
+
+        const events = [];
+        this.queueGenerateEventGameSteps(events, context);
         context.game.queueSimpleStep(() => context.game.openEventWindow(events), `openEventWindow for '${this}'`);
     }
 

--- a/server/game/core/gameSystem/GameSystem.ts
+++ b/server/game/core/gameSystem/GameSystem.ts
@@ -146,9 +146,14 @@ export abstract class GameSystem<TProperties extends IGameSystemProperties = IGa
     }
 
     /**
-     * Generates a list of {@link GameEvent} objects that will apply the effects of this system to the game state
-     * by generating one event per target in `context.targets`.
-     * The events must be emitted using an {@link EventWindow}, typically via `Game.openEventWindow`.
+     * Generates events to apply the effects of this system to the game state by generating one event per configured target.
+     * Targets must be configured either using the system initialization properties or context properties.
+     *
+     * The generated events will be pushed onto the `events` parameter array. Many implementations of this method will
+     * accomplish this by queueing game steps that generate the events, so anything that would leverage the generated events
+     * (typically an event window) must be queued as its own game step so it is guaranteed to resolve after events are generated.
+     *
+     * @param events Generated events will be appended to this list
      * @param context Context of ability being executed
      * @param additionalProperties Any additional properties to extend the default ones with
      */

--- a/server/game/core/gameSystem/LastingEffectSystem.ts
+++ b/server/game/core/gameSystem/LastingEffectSystem.ts
@@ -56,12 +56,10 @@ export class LastingEffectAction extends GameSystem<LastingEffectProperties> {
         return properties.effect.length > 0;
     }
 
-    public override generateEventsForAllTargets(context: AbilityContext, additionalProperties: any): GameEvent[] {
-        const events: GameEvent[] = [];
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties: any): void {
         if (this.hasLegalTarget(context, additionalProperties)) {
             events.push(this.generateEvent(null, context, additionalProperties));
         }
-        return events;
     }
 
     // TODO: refactor GameSystem so this class doesn't need to override this method (it isn't called since we override hasLegalTarget)

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -73,7 +73,8 @@ export class OngoingEffectEngine {
                         }
                         this.game.addMessage(properties.message, ...messageArgs);
                     }
-                    const actionEvents = properties.gameAction.generateEventsForAllTargets(context);
+                    const actionEvents = [];
+                    properties.gameAction.queueGenerateEventGameSteps(actionEvents, context);
                     this.game.queueSimpleStep(() => this.game.openThenEventWindow(actionEvents), 'openAdditionThenEventWindow');  // TODO: why is it using this window type?
                     this.game.queueSimpleStep(() => context.refill(), 'context.refill');  // TODO EFFECTS: this is supposed to be calling resolveGameState
                 }

--- a/server/game/costs/CostLibrary.ts
+++ b/server/game/costs/CostLibrary.ts
@@ -469,7 +469,7 @@ export function abilityResourceCost(amount: number | ((context: AbilityContext) 
 //                 return doNothing.generateEvent(context.player, context);
 //             }
 
-//             return cost.generateEventsForAllTargets(context, {});
+//             return cost.queueGenerateEventGameSteps(context, {});
 //         }
 //     };
 // }

--- a/server/game/costs/CostLibrary.ts
+++ b/server/game/costs/CostLibrary.ts
@@ -10,7 +10,7 @@ import { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext
 import { Derivable, derive } from '../core/utils/Helpers';
 import { Card } from '../core/card/Card';
 import { ICost } from '../core/cost/ICost';
-import { GameActionCost } from '../core/cost/GameActionCost';
+import { GameSystemCost } from '../core/cost/GameSystemCost';
 import { MetaActionCost } from '../core/cost/MetaActionCost';
 import { PlayCardResourceCost } from './PlayCardResourceCost';
 import { ReturnToHandFromPlaySystem } from '../gameSystems/ReturnToHandFromPlaySystem';
@@ -34,14 +34,14 @@ function getSelectCost(
  * Cost that will bow the card that initiated the ability.
  */
 export function exhaustSelf(): ICost {
-    return new GameActionCost(GameSystems.exhaust({ isCost: true }));
+    return new GameSystemCost(GameSystems.exhaust({ isCost: true }));
 }
 
 // /**
 //  * Cost that will sacrifice the card that initiated the ability.
 //  */
 // export function sacrificeSelf(): Cost {
-//     return new GameActionCost(GameSystems.sacrifice());
+//     return new GameSystemCost(GameSystems.sacrifice());
 // }
 
 // /**
@@ -56,7 +56,7 @@ export function exhaustSelf(): ICost {
  * Cost that will return to hand from the play area the card that initiated the ability
  */
 export function returnSelfToHandFromPlay(): ICost {
-    return new GameActionCost(GameSystems.returnToHandFromPlay({ isCost: true }));
+    return new GameSystemCost(GameSystems.returnToHandFromPlay({ isCost: true }));
 }
 
 /**
@@ -88,7 +88,7 @@ export function returnToHandFromPlay(properties: SelectCostProperties): ICost {
 //  * Cost that will return to hand the card that initiated the ability.
 //  */
 // export function returnSelfToHand(): Cost {
-//     return new GameActionCost(GameSystems.returnToHand());
+//     return new GameSystemCost(GameSystems.returnToHand());
 // }
 
 /**
@@ -108,14 +108,14 @@ export function shuffleIntoDeck(properties: SelectCostProperties): ICost {
 //  * Cost that requires discarding a specific card.
 //  */
 // export function discardCardSpecific(cardFunc: (context: AbilityContext) => BaseCard): Cost {
-//     return new GameActionCost(GameSystems.discardCard((context) => ({ target: cardFunc(context) })));
+//     return new GameSystemCost(GameSystems.discardCard((context) => ({ target: cardFunc(context) })));
 // }
 
 // /**
 //  * Cost that requires discarding itself from hand.
 //  */
 // export function discardSelf(): Cost {
-//     return new GameActionCost(GameSystems.discardCard((context) => ({ target: context.source })));
+//     return new GameSystemCost(GameSystems.discardCard((context) => ({ target: context.source })));
 // }
 
 // /**
@@ -157,7 +157,7 @@ export function shuffleIntoDeck(properties: SelectCostProperties): ICost {
 //  * Cost that requires removing a card selected by the player from the game.
 //  */
 // export function removeSelfFromGame(properties?: { location: Array<Location> }): Cost {
-//     return new GameActionCost(GameSystems.removeFromGame(properties));
+//     return new GameSystemCost(GameSystems.removeFromGame(properties));
 // }
 
 // export function discardStatusToken(properties: Omit<SelectCardProperties, 'gameSystem' | 'subActionProperties'>): Cost {
@@ -179,14 +179,14 @@ export function shuffleIntoDeck(properties: SelectCostProperties): ICost {
 //  * Cost that will discard the status token on a card to be selected by the player
 //  */
 // export function discardStatusTokenFromSelf(): Cost {
-//     return new GameActionCost(GameSystems.discardStatusToken());
+//     return new GameSystemCost(GameSystems.discardStatusToken());
 // }
 
 /**
  * Cost that will put into play the card that initiated the ability
  */
 export function putSelfIntoPlay(): ICost {
-    return new GameActionCost(GameSystems.putIntoPlay());
+    return new GameSystemCost(GameSystems.putIntoPlay());
 }
 
 // /**
@@ -200,7 +200,7 @@ export function putSelfIntoPlay(): ICost {
 //  * Cost that will reveal specific cards
 //  */
 // export function reveal(cardFunc: (context: AbilityContext) => BaseCard[]): Cost {
-//     return new GameActionCost(GameSystems.reveal((context) => ({ target: cardFunc(context) })));
+//     return new GameSystemCost(GameSystems.reveal((context) => ({ target: cardFunc(context) })));
 // }
 
 // /**
@@ -247,7 +247,7 @@ export function payPlayCardResourceCost(ignoreType = false): ICost {
  * Cost in which the player must pay a fixed, non-reduceable amount of fate.
  */
 export function abilityResourceCost(amount: number | ((context: AbilityContext) => number)): ICost {
-    return new GameActionCost(
+    return new GameSystemCost(
         typeof amount === 'function'
             ? GameSystems.payResourceCost((context) => ({ target: context.player, amount: amount(context) }))
             : GameSystems.payResourceCost((context) => ({ target: context.player, amount }))

--- a/server/game/gameSystems/AttackSystem.ts
+++ b/server/game/gameSystems/AttackSystem.ts
@@ -129,7 +129,7 @@ export class AttackSystem extends CardTargetSystem<IAttackProperties> {
         properties.costHandler(context, prompt);
     }
 
-    public override generateEventsForAllTargets(context: AbilityContext, additionalProperties = {}): GameEvent[] {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
         const { target } = this.generatePropertiesFromContext(
             context,
             additionalProperties
@@ -137,13 +137,12 @@ export class AttackSystem extends CardTargetSystem<IAttackProperties> {
 
         const cards = (target as Card[]).filter((card) => this.canAffect(card, context));
         if (cards.length !== 1) {
-            return [];
+            return;
         }
 
         const event = this.createEvent(null, context, additionalProperties);
         this.updateEvent(event, cards, context, additionalProperties);
-
-        return [event];
+        events.push(event);
     }
 
     protected override addPropertiesToEvent(event, target, context: AbilityContext, additionalProperties): void {
@@ -219,13 +218,9 @@ export class AttackSystem extends CardTargetSystem<IAttackProperties> {
             const effectProperties = typeof effect === 'function' ? effect(context, attack) : effect;
 
             const effectSystem = new LastingEffectCardSystem(effectProperties);
-            effectEvents.push(...effectSystem.generateEventsForAllTargets(context));
+            effectSystem.queueGenerateEventGameSteps(effectEvents, context);
         }
 
-        // trigger events
-        context.game.openEventWindow(effectEvents);
-
-        // TODO EFFECTS: remove this hack
-        context.game.queueSimpleStep(() => context.game.resolveGameState(), 'resolveGameState for AttackSystem');
+        context.game.queueSimpleStep(() => context.game.openEventWindow(effectEvents), 'open event window for attack effects');
     }
 }

--- a/server/game/gameSystems/ConditionalSystem.ts
+++ b/server/game/gameSystems/ConditionalSystem.ts
@@ -33,8 +33,8 @@ export class ConditionalSystem extends GameSystem<IConditionalSystemProperties> 
         return this.getGameAction(context, additionalProperties).hasLegalTarget(context, additionalProperties);
     }
 
-    public override generateEventsForAllTargets(context: AbilityContext, additionalProperties = {}): GameEvent[] {
-        return this.getGameAction(context, additionalProperties).generateEventsForAllTargets(context, additionalProperties);
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+        this.getGameAction(context, additionalProperties).queueGenerateEventGameSteps(events, context, additionalProperties);
     }
 
     public override hasTargetsChosenByInitiatingPlayer(context: AbilityContext, additionalProperties = {}): boolean {

--- a/server/game/gameSystems/ExecuteHandlerSystem.ts
+++ b/server/game/gameSystems/ExecuteHandlerSystem.ts
@@ -32,8 +32,8 @@ export class ExecuteHandlerSystem extends GameSystem {
         return true;
     }
 
-    public override generateEventsForAllTargets(context: AbilityContext, additionalProperties = {}): GameEvent[] {
-        return [this.generateEvent(null, context, additionalProperties)];
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+        events.push(this.generateEvent(null, context, additionalProperties));
     }
 
     public override hasTargetsChosenByInitiatingPlayer(context: AbilityContext, additionalProperties = {}) {

--- a/server/game/gameSystems/ReplacementEffectSystem.ts
+++ b/server/game/gameSystems/ReplacementEffectSystem.ts
@@ -1,4 +1,5 @@
 import { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
+import { GameEvent } from '../core/event/GameEvent';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
 import Contract from '../core/utils/Contract';
 
@@ -17,7 +18,9 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
 
         if (replacementGameAction) {
             const eventWindow = event.context.event.window;
-            const events = replacementGameAction.generateEventsForAllTargets(
+            const events = [];
+            replacementGameAction.queueGenerateEventGameSteps(
+                events,
                 event.context,
                 Object.assign({ replacementEffect: true }, additionalProperties)
             );
@@ -34,13 +37,13 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
         event.context.cancel();
     }
 
-    public override generateEventsForAllTargets(context: TriggeredAbilityContext, additionalProperties = {}) {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TriggeredAbilityContext, additionalProperties = {}) {
         const event = this.createEvent(null, context, additionalProperties);
 
         super.addPropertiesToEvent(event, null, context, additionalProperties);
         event.replaceHandler((event) => this.eventHandler(event, additionalProperties));
 
-        return [event];
+        events.push(event);
     }
 
     public override getEffectMessage(context: TriggeredAbilityContext): [string, any[]] {

--- a/server/game/gameSystems/SearchDeckSystem.ts
+++ b/server/game/gameSystems/SearchDeckSystem.ts
@@ -103,9 +103,7 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         event.amount = searchCountAmount;
     }
 
-    public override generateEventsForAllTargets(context: AbilityContext, additionalProperties = {}): GameEvent[] {
-        const events: GameEvent[] = [];
-
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const player = properties.player || context.player;
         const event = this.generateEvent(player, context, additionalProperties) as any;
@@ -115,10 +113,8 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         if (event.amount === -1) {
             cards = cards.filter((card) => properties.cardCondition(card, context));
         }
-        events.push(event);
         this.selectCard(event, additionalProperties, cards, new Set());
-
-        return events;
+        events.push(event);
     }
 
     private getNumCards(numCards: Derivable<number>, context: AbilityContext): number {

--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -92,11 +92,10 @@ export class SelectCardSystem extends CardTargetSystem {
         return properties.selector.hasEnoughTargets(context, player);
     }
 
-    // TODO: this was previously accepting an event input and using it in the in 'OnSelect' method. not sure if changing that change broke anything
-    public override generateEventsForAllTargets(context: AbilityContext, additionalProperties = {}): GameEvent[] {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         if (properties.player === RelativePlayer.Opponent && !context.player.opponent) {
-            return [];
+            return;
         }
         let player = properties.player === RelativePlayer.Opponent ? context.player.opponent : context.player;
         let mustSelect = [];
@@ -111,7 +110,7 @@ export class SelectCardSystem extends CardTargetSystem {
                 );
         }
         if (!properties.selector.hasEnoughTargets(context, player)) {
-            return [];
+            return;
         }
         const defaultProperties = {
             context: context,
@@ -123,7 +122,8 @@ export class SelectCardSystem extends CardTargetSystem {
                 if (properties.message) {
                     context.game.addMessage(properties.message, ...properties.messageArgs(cards, player, properties));
                 }
-                const events = properties.innerSystem.generateEventsForAllTargets(
+                properties.innerSystem.queueGenerateEventGameSteps(
+                    events,
                     context,
                     Object.assign({ parentAction: this }, additionalProperties, properties.innerSystemProperties(cards))
                 );
@@ -138,11 +138,11 @@ export class SelectCardSystem extends CardTargetSystem {
             const cards = properties.selector.getAllLegalTargets(context);
             if (cards.length === 1) {
                 finalProperties.onSelect(player, cards[0]);
-                return [];
+                return;
             }
         }
         context.game.promptForSelect(player, finalProperties);
-        return [];
+        return;
     }
 
     public override hasTargetsChosenByInitiatingPlayer(context: AbilityContext, additionalProperties = {}): boolean {

--- a/server/game/gameSystems/ViewCardSystem.ts
+++ b/server/game/gameSystems/ViewCardSystem.ts
@@ -34,19 +34,15 @@ export abstract class ViewCardSystem extends CardTargetSystem<IViewCardPropertie
         }
     }
 
-    public override generateEventsForAllTargets(context: AbilityContext, additionalProperties = {}): GameEvent[] {
-        const events: GameEvent[] = [];
-
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
         const { target } = this.generatePropertiesFromContext(context, additionalProperties);
         const cards = (target as BaseCard[]).filter((card) => this.canAffect(card, context));
         if (cards.length === 0) {
-            return [];
+            return;
         }
         const event = this.createEvent(null, context, additionalProperties);
         this.updateEvent(event, cards, context, additionalProperties);
         events.push(event);
-
-        return events;
     }
 
     public override addPropertiesToEvent(event, cards, context: AbilityContext, additionalProperties): void {


### PR DESCRIPTION
Realized that some of the "meta" game systems from the legacy L5R code override the event generation method to queue game steps which generate the events. Refactored the existing `generateEventsForAllTargets` method back to the way it was to be able to support that usage, but renamed it to `queueGenerateEventGameSteps` to make the purpose and usage clearer.