### PR TITLE
Fix "when defeated" trigger issues, add Vanguard Infantry

### DIFF
--- a/server/game/cards/01_SOR/VanguardInfantry.ts
+++ b/server/game/cards/01_SOR/VanguardInfantry.ts
@@ -1,0 +1,23 @@
+import AbilityHelper from '../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../core/card/NonLeaderUnitCard';
+
+export default class VanguardInfantry extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '5575681343',
+            internalName: 'vanguard-infantry',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addWhenDefeatedAbility({
+            title: 'Give an experience token to a unit',
+            optional: true,
+            targetResolver: {
+                immediateEffect: AbilityHelper.immediateEffects.giveExperience()
+            }
+        });
+    }
+}
+
+VanguardInfantry.implemented = true;

--- a/server/game/cards/01_SOR/VanguardInfantry.ts
+++ b/server/game/cards/01_SOR/VanguardInfantry.ts
@@ -11,7 +11,7 @@ export default class VanguardInfantry extends NonLeaderUnitCard {
 
     public override setupCardAbilities() {
         this.addWhenDefeatedAbility({
-            title: 'Give an experience token to a unit',
+            title: 'Give an Experience token to a unit',
             optional: true,
             targetResolver: {
                 immediateEffect: AbilityHelper.immediateEffects.giveExperience()

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -48,6 +48,7 @@ export default class TriggeredAbility extends CardAbility {
     public anyPlayer: boolean;
     public collectiveTrigger: boolean;
     public eventRegistrations?: IEventRegistration[];
+    public eventsTriggeredFor: GameEvent[] = [];
 
     public constructor(
         game: Game,
@@ -80,8 +81,10 @@ export default class TriggeredAbility extends CardAbility {
             if (
                 (this.card as CardWithTriggeredAbilities).getTriggeredAbilities().includes(this) &&
                 this.isTriggeredByEvent(event, context) &&
-                this.meetsRequirements(context) === ''
+                this.meetsRequirements(context) === '' &&
+                !this.eventsTriggeredFor.includes(event)
             ) {
+                this.eventsTriggeredFor.push(event);
                 window.addToWindow(context);
             }
         }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -86,6 +86,11 @@ export class InPlayCard extends PlayableOrDeployableCard {
         this.addTriggeredAbility(triggeredProperties);
     }
 
+    protected addWhenDefeatedAbility(properties: Omit<ITriggeredAbilityProps, 'when' | 'aggregateWhen'>): void {
+        const triggeredProperties = Object.assign(properties, { when: { onCardDefeated: (event, context) => event.card === context.source } });
+        this.addTriggeredAbility(triggeredProperties);
+    }
+
     public createConstantAbility(properties: IConstantAbilityProps<this>): IConstantAbility {
         properties.cardName = this.title;
 

--- a/server/game/core/event/EventWindow.js
+++ b/server/game/core/event/EventWindow.js
@@ -2,6 +2,7 @@ const { BaseStepWithPipeline } = require('../gameSteps/BaseStepWithPipeline.js')
 const { TriggeredAbilityWindow } = require('../gameSteps/abilityWindow/TriggeredAbilityWindow');
 const { SimpleStep } = require('../gameSteps/SimpleStep.js');
 const { AbilityType } = require('../Constants.js');
+const { default: Contract } = require('../utils/Contract.js');
 // const KeywordAbilityWindow = require('../gamesteps/keywordabilitywindow.js');
 
 class EventWindow extends BaseStepWithPipeline {
@@ -18,6 +19,8 @@ class EventWindow extends BaseStepWithPipeline {
 
         this.toStringName = `'EventWindow: ${this.events.map((event) => event.name).join(', ')}'`;
 
+        this.triggeredAbilityWindow = null;
+
         this.initialise();
     }
 
@@ -25,13 +28,13 @@ class EventWindow extends BaseStepWithPipeline {
         this.pipeline.initialise([
             new SimpleStep(this.game, () => this.setCurrentEventWindow(), 'setCurrentEventWindow'),
             new SimpleStep(this.game, () => this.checkEventCondition(), 'checkEventCondition'),
-            new SimpleStep(this.game, () => this.openWindow(AbilityType.ReplacementEffect), 'open ReplacementEffect window'),
+            new SimpleStep(this.game, () => this.openNonTriggeredWindow(AbilityType.ReplacementEffect), 'openNonTriggeredWindow'),
             new SimpleStep(this.game, () => this.createContingentEvents(), 'createContingentEvents'),
             new SimpleStep(this.game, () => this.preResolutionEffects(), 'preResolutionEffects'),
             new SimpleStep(this.game, () => this.executeHandler(), 'executeHandler'),
             new SimpleStep(this.game, () => this.resolveGameState(), 'resolveGameState'),    // TODO EFFECTS: uncomment this (and other places the method is used, + missing ones from l5r)
             new SimpleStep(this.game, () => this.checkThenAbilitySteps(), 'checkThenAbilitySteps'),
-            new SimpleStep(this.game, () => this.openWindow(AbilityType.Triggered), 'open TriggeredAbility window'),
+            new SimpleStep(this.game, () => this.openTriggeredAbilityWindow(), 'openTriggeredAbilityWindow'),
             new SimpleStep(this.game, () => this.resetCurrentEventWindow(), 'resetCurrentEventWindow')
         ]);
     }
@@ -60,14 +63,21 @@ class EventWindow extends BaseStepWithPipeline {
         this.events.forEach((event) => event.checkCondition());
     }
 
-    openWindow(abilityType) {
+    /** open a triggering window for any ability type other than {@link AbilityType.Triggered} */
+    openNonTriggeredWindow(abilityType) {
+        if (!Contract.assertNotEqual(abilityType, AbilityType.Triggered)) {
+            return;
+        }
+
         if (this.events.length === 0) {
             return;
         }
 
         // TODO EFFECTS: will need resolution for replacement effects here
         // not sure if it will need a new window class or can just reuse the existing one
-        this.queueStep(new TriggeredAbilityWindow(this.game, this, abilityType));
+        const window = new TriggeredAbilityWindow(this.game, this, abilityType);
+        window.emitEvents();
+        this.queueStep(window);
     }
 
     /**
@@ -90,6 +100,9 @@ class EventWindow extends BaseStepWithPipeline {
     executeHandler() {
         this.eventsToExecute = this.events.sort((event) => event.order);
 
+        // we emit triggered abilities here to ensure that they get triggered in case e.g. a card is defeated during event resolution
+        this.triggerEventsForWindow();
+
         for (const event of this.eventsToExecute) {
             // need to checkCondition here to ensure the event won't fizzle due to another event's resolution (e.g. double honoring an ordinary character with YR etc.)
             event.checkCondition();
@@ -98,6 +111,17 @@ class EventWindow extends BaseStepWithPipeline {
                 this.game.emit(event.name, event);
             }
         }
+
+        // TODO: make it so we don't need to trigger twice
+        // trigger again here to catch any events for cards that entered play during event resolution
+        this.triggerEventsForWindow();
+    }
+
+    triggerEventsForWindow() {
+        if (this.triggeredAbilityWindow === null) {
+            this.triggeredAbilityWindow = new TriggeredAbilityWindow(this.game, this, AbilityType.Triggered);
+        }
+        this.triggeredAbilityWindow.emitEvents();
     }
 
     resolveGameState() {
@@ -114,6 +138,14 @@ class EventWindow extends BaseStepWithPipeline {
                 this.game.resolveAbility(cardAbilityStep.ability.createContext(cardAbilityStep.context.player));
             }
         }
+    }
+
+    openTriggeredAbilityWindow() {
+        if (this.events.length === 0) {
+            return;
+        }
+
+        this.queueStep(this.triggeredAbilityWindow);
     }
 
     resetCurrentEventWindow() {

--- a/server/game/core/event/EventWindow.js
+++ b/server/game/core/event/EventWindow.js
@@ -28,7 +28,7 @@ class EventWindow extends BaseStepWithPipeline {
         this.pipeline.initialise([
             new SimpleStep(this.game, () => this.setCurrentEventWindow(), 'setCurrentEventWindow'),
             new SimpleStep(this.game, () => this.checkEventCondition(), 'checkEventCondition'),
-            new SimpleStep(this.game, () => this.openNonTriggeredWindow(AbilityType.ReplacementEffect), 'openNonTriggeredWindow'),
+            new SimpleStep(this.game, () => this.openReplacementEffectWindow(), 'openReplacementEffectWindow'),
             new SimpleStep(this.game, () => this.createContingentEvents(), 'createContingentEvents'),
             new SimpleStep(this.game, () => this.preResolutionEffects(), 'preResolutionEffects'),
             new SimpleStep(this.game, () => this.executeHandler(), 'executeHandler'),
@@ -63,19 +63,14 @@ class EventWindow extends BaseStepWithPipeline {
         this.events.forEach((event) => event.checkCondition());
     }
 
-    /** open a triggering window for any ability type other than {@link AbilityType.Triggered} */
-    openNonTriggeredWindow(abilityType) {
-        if (!Contract.assertNotEqual(abilityType, AbilityType.Triggered)) {
-            return;
-        }
-
+    openReplacementEffectWindow() {
         if (this.events.length === 0) {
             return;
         }
 
         // TODO EFFECTS: will need resolution for replacement effects here
         // not sure if it will need a new window class or can just reuse the existing one
-        const window = new TriggeredAbilityWindow(this.game, this, abilityType);
+        const window = new TriggeredAbilityWindow(this.game, this, AbilityType.ReplacementEffect);
         window.emitEvents();
         this.queueStep(window);
     }

--- a/server/game/core/event/ThenEventWindow.js
+++ b/server/game/core/event/ThenEventWindow.js
@@ -11,10 +11,8 @@ const { AbilityType } = require('../Constants.js');
  */
 class ThenEventWindow extends EventWindow {
     /** @override */
-    openWindow(abilityType) {
-        if (abilityType !== AbilityType.Triggered) {
-            super.openWindow(abilityType);
-        }
+    openTriggeredAbilityWindow() {
+        // we are deliberately not activating triggers here because they are being passed back to the calling window
     }
 
     /** @override */
@@ -22,6 +20,10 @@ class ThenEventWindow extends EventWindow {
         for (let event of this.events) {
             this.previousEventWindow.addEvent(event);
         }
+        for (const triggeredAbility of this.triggeredAbilityWindow.triggeredAbilities) {
+            this.previousEventWindow.triggeredAbilityWindow.addToWindow(triggeredAbility);
+        }
+
         super.resetCurrentEventWindow();
     }
 }

--- a/server/game/core/gameSteps/abilityWindow/InitiateAbilityEventWindow.js
+++ b/server/game/core/gameSteps/abilityWindow/InitiateAbilityEventWindow.js
@@ -64,6 +64,9 @@ class InitiateAbilityEventWindow extends EventWindow {
     executeHandler() {
         this.eventsToExecute = this.events.sort((event) => event.order);
 
+        // we emit triggered abilities here to ensure that they get triggered in case e.g. a card is defeated during event resolution
+        this.triggerEventsForWindow();
+
         this.eventsToExecute.forEach((event) => {
             event.checkCondition();
             if (!event.cancelled) {

--- a/server/game/core/utils/Contract.ts
+++ b/server/game/core/utils/Contract.ts
@@ -85,8 +85,16 @@ export function assertFalse(cond: boolean, message?: string): boolean {
 }
 
 export function assertEqual(val1: any, val2: any, message?: string): boolean {
-    if (!(val1 === val2)) {
+    if (val1 !== val2) {
         contractCheckImpl.fail(message ?? `Value ${val1} is not equal to ${val2}`);
+        return false;
+    }
+    return true;
+}
+
+export function assertNotEqual(val1: any, val2: any, message?: string): boolean {
+    if (val1 === val2) {
+        contractCheckImpl.fail(message ?? `Value ${val1} is equal to ${val2}`);
         return false;
     }
     return true;
@@ -189,6 +197,7 @@ const Contract = {
     assertTrue,
     assertFalse,
     assertEqual,
+    assertNotEqual,
     assertNotNull,
     assertNotNullLike,
     assertNotNullLikeOrNan,

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -523,6 +523,10 @@ var customMatchers = {
                 if (!card.upgrades) {
                     throw new Error(`Card ${card.internalName} does not have an upgrades property`);
                 }
+                if (!Array.isArray(upgradeNames)) {
+                    // TODO: create a "TestError" class to make it easier to tell when an error is coming from the test infra
+                    throw new Error(`Parameter upgradeNames is not an array: ${upgradeNames}`);
+                }
 
                 const actualUpgradeNames = card.upgrades.map((upgrade) => upgrade.internalName);
 

--- a/test/server/cards/01_SOR/VanguardInfantry.spec.js
+++ b/test/server/cards/01_SOR/VanguardInfantry.spec.js
@@ -1,0 +1,29 @@
+describe('Vanguard Infantry', function() {
+    integration(function() {
+        describe('Vanguard Infantry\'s when defeated ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['vanquish'],
+                        groundArena: ['battlefield-marine', 'vanguard-infantry'],
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+            });
+
+            it('should give an experience token to a unit when defeated in combat', function () {
+                this.player1.clickCard(this.vanguardInfantry);
+                this.player1.clickCard(this.wampa);
+                expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.wampa, this.cartelSpacer]);
+                expect(this.player1).toHaveEnabledPromptButton('Pass ability');
+
+                this.player1.clickCard(this.cartelSpacer);
+                expect(this.cartelSpacer).toHaveExactUpgradeNames(['experience']);
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/VanguardInfantry.spec.js
+++ b/test/server/cards/01_SOR/VanguardInfantry.spec.js
@@ -24,6 +24,26 @@ describe('Vanguard Infantry', function() {
                 this.player1.clickCard(this.cartelSpacer);
                 expect(this.cartelSpacer).toHaveExactUpgradeNames(['experience']);
             });
+
+            it('should give an experience token to a unit when defeated by an ability', function () {
+                this.player1.clickCard(this.vanquish);
+                this.player1.clickCard(this.vanguardInfantry);
+                expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.wampa, this.cartelSpacer]);
+                expect(this.player1).toHaveEnabledPromptButton('Pass ability');
+
+                this.player1.clickCard(this.battlefieldMarine);
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames(['experience']);
+            });
+
+            it('should be able to be passed', function () {
+                this.player1.clickCard(this.vanguardInfantry);
+                this.player1.clickCard(this.wampa);
+                this.player1.clickPrompt('Pass ability');
+
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames([]);
+                expect(this.wampa).toHaveExactUpgradeNames([]);
+                expect(this.cartelSpacer).toHaveExactUpgradeNames([]);
+            });
         });
     });
 });


### PR DESCRIPTION
We discovered a bug causing when-defeated triggers to completely fail. The reason was that triggers were being activated after events were resolved, so if a card left the arena during the event resolution window (e.g. due to defeat resolving) then its abilities would be unregistered and the defeat ability would never fire.

As a (possibly temporary) mitigation, we changed the resolution to work as follows:

1. Triggers are activated before event resolution, all triggered abilities are saved
2. Resolve event(s)
3. Activate triggers _again_ to catch any triggers such as when-played that would've been missed at step 1. Duplicate triggers are ignored.
4. Check if any triggering events were cancelled; if so, remove the relevant triggered abilities from the list to resolve
5. Resolve all remaining triggered abilities

If the ability is a "then" ability (i.e. triggers are being held until the parent ability finishes resolving), we don't active any triggers but instead add them to the parent triggered ability window.

Added Vangard Infantry as a proof card to confirm that everything is working.

TODO: we need to investigate whether it would be better for cards to have their abilities online while not in the arena, to simplify cases like this. It's also needed for exploit and possibly ambush.