### PR TITLE
Add system for "if" conditions and some cards to test triggered and constant abilities

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -30,7 +30,7 @@ jobs:
           uses: actions/cache@v3
           with:
             path: ./test/json
-            key: sor-shd-manual-v03-types
+            key: sor-shd-manual-v04-specialchars
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards
 

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -24,7 +24,7 @@ jobs:
           uses: actions/cache@v3
           with:
             path: ./test/json
-            key: sor-shd-manual-v03-specialchars
+            key: sor-shd-manual-v04-specialchars
 
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards

--- a/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
+++ b/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
@@ -12,7 +12,7 @@ export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
 
     public static buildSaboteurAbilityProperties(): ITriggeredAbilityProps {
         return {
-            title: 'Saboteur',
+            title: 'Saboteur: defeat all shields',
             when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
             targetResolver: {
                 cardCondition: (card: Card, context: TriggeredAbilityContext) => {

--- a/server/game/cards/01_SOR/FallenLightsaber.ts
+++ b/server/game/cards/01_SOR/FallenLightsaber.ts
@@ -1,0 +1,35 @@
+import AbilityHelper from '../../AbilityHelper';
+import { Card } from '../../core/card/Card';
+import { UpgradeCard } from '../../core/card/UpgradeCard';
+import { CardType, KeywordName, Location, Trait, WildcardCardType } from '../../core/Constants';
+import Player from '../../core/Player';
+
+export default class FallenLightsaber extends UpgradeCard {
+    protected override getImplementationId() {
+        return {
+            id: '0160548661',
+            internalName: 'fallen-lightsaber',
+        };
+    }
+
+    public override canAttach(targetCard: Card, controller: Player = this.controller): boolean {
+        if (targetCard.hasSomeTrait(Trait.Vehicle)) {
+            return false;
+        }
+
+        return super.canAttach(targetCard, controller);
+    }
+
+    public override setupCardAbilities() {
+        this.addGainTriggeredAbilityTargetingAttached({
+            title: 'Deal 1 damage to each ground unit the defending player controls',
+            when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
+            immediateEffect: AbilityHelper.immediateEffects.damage((context) => {
+                return { target: context.source.controller.opponent.getUnitsInPlay(Location.GroundArena), amount: 1 };
+            })
+        },
+        (context) => context.source.parentCard?.hasSomeTrait(Trait.Force));
+    }
+}
+
+FallenLightsaber.implemented = true;

--- a/server/game/cards/01_SOR/JedhaAgitator.ts
+++ b/server/game/cards/01_SOR/JedhaAgitator.ts
@@ -16,7 +16,7 @@ export default class JedhaAgitator extends NonLeaderUnitCard {
             targetResolver: {
                 cardCondition: (card) => (card.isUnit() && card.location === Location.GroundArena) || card.isBase(),
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => context.source.controller.leader.isDeployed,
+                    condition: (context) => context.source.controller.leader.deployed,
                     trueImmediateEffect: AbilityHelper.immediateEffects.damage({ amount: 2 }),
                     falseImmediateEffect: AbilityHelper.immediateEffects.noAction()
                 })

--- a/server/game/cards/01_SOR/JedhaAgitator.ts
+++ b/server/game/cards/01_SOR/JedhaAgitator.ts
@@ -1,0 +1,28 @@
+import AbilityHelper from '../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../core/card/NonLeaderUnitCard';
+import { Location } from '../../core/Constants';
+
+export default class JedhaAgitator extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '1746195484',
+            internalName: 'jedha-agitator',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addOnAttackAbility({
+            title: 'If you control a leader unit, deal 2 damage to a ground unit or base',
+            targetResolver: {
+                cardCondition: (card) => (card.isUnit() && card.location === Location.GroundArena) || card.isBase(),
+                immediateEffect: AbilityHelper.immediateEffects.conditional({
+                    condition: (context) => context.source.controller.leader.isDeployed,
+                    trueImmediateEffect: AbilityHelper.immediateEffects.damage({ amount: 2 }),
+                    falseImmediateEffect: AbilityHelper.immediateEffects.noAction()
+                })
+            }
+        });
+    }
+}
+
+JedhaAgitator.implemented = true;

--- a/server/game/cards/01_SOR/VadersLightsaber.ts
+++ b/server/game/cards/01_SOR/VadersLightsaber.ts
@@ -1,0 +1,43 @@
+import AbilityHelper from '../../AbilityHelper';
+import { Card } from '../../core/card/Card';
+import { UpgradeCard } from '../../core/card/UpgradeCard';
+import { CardType, KeywordName, Location, Trait, WildcardCardType } from '../../core/Constants';
+import Player from '../../core/Player';
+
+export default class VadersLightsaber extends UpgradeCard {
+    protected override getImplementationId() {
+        return {
+            id: '0705773109',
+            internalName: 'vaders-lightsaber',
+        };
+    }
+
+    public override canAttach(targetCard: Card, controller: Player = this.controller): boolean {
+        if (targetCard.hasSomeTrait(Trait.Vehicle)) {
+            return false;
+        }
+
+        return super.canAttach(targetCard, controller);
+    }
+
+    public override setupCardAbilities() {
+        this.addWhenPlayedAbility({
+            title: 'If attached unit is Darth Vader, you may deal 4 damage to a ground unit',
+            immediateEffect: AbilityHelper.immediateEffects.conditional({
+                condition: (context) => context.source.parentCard?.title === 'Darth Vader',
+                trueImmediateEffect: this.vaderLightsaberAbility(),
+                falseImmediateEffect: AbilityHelper.immediateEffects.noAction()
+            })
+        });
+    }
+
+    private vaderLightsaberAbility() {
+        return AbilityHelper.immediateEffects.selectCard({
+            locationFilter: Location.GroundArena,
+            cardTypeFilter: WildcardCardType.Unit,
+            innerSystem: AbilityHelper.immediateEffects.damage({ amount: 4 })
+        });
+    }
+}
+
+VadersLightsaber.implemented = true;

--- a/server/game/cards/01_SOR/VadersLightsaber.ts
+++ b/server/game/cards/01_SOR/VadersLightsaber.ts
@@ -22,7 +22,8 @@ export default class VadersLightsaber extends UpgradeCard {
 
     public override setupCardAbilities() {
         this.addWhenPlayedAbility({
-            title: 'If attached unit is Darth Vader, you may deal 4 damage to a ground unit',
+            title: 'Deal 4 damage to a ground unit',
+            optional: true,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) => context.source.parentCard?.title === 'Darth Vader',
                 trueImmediateEffect: this.vaderLightsaberAbility(),

--- a/server/game/cards/01_SOR/YodaOldMaster.ts
+++ b/server/game/cards/01_SOR/YodaOldMaster.ts
@@ -20,7 +20,7 @@ export default class YodaOldMaster extends NonLeaderUnitCard {
                     ['Me']: AbilityHelper.immediateEffects.draw({ target: context.source.owner }),
                     ['Opponent']: AbilityHelper.immediateEffects.draw({ target: context.source.owner.opponent }),
                     ['Me and Opponent']: AbilityHelper.immediateEffects.draw({ target: [context.source.owner, context.source.owner.opponent] }),
-                    ['No one']: AbilityHelper.immediateEffects.noAction()
+                    ['No one']: AbilityHelper.immediateEffects.noAction({ hasLegalTarget: true })
                 })
             }
         });

--- a/server/game/cards/02_SHD/VambraceGrappleshot.ts
+++ b/server/game/cards/02_SHD/VambraceGrappleshot.ts
@@ -1,4 +1,5 @@
 import AbilityHelper from '../../AbilityHelper';
+import { TriggeredAbilityContext } from '../../core/ability/TriggeredAbilityContext';
 import { Card } from '../../core/card/Card';
 import { UpgradeCard } from '../../core/card/UpgradeCard';
 import { Trait } from '../../core/Constants';
@@ -24,10 +25,9 @@ export default class VambraceGrappleshot extends UpgradeCard {
         this.addGainTriggeredAbilityTargetingAttached({
             title: 'Exhaust the defender on attack',
             when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
-            targetResolver: {
-                cardCondition: (card, context) => card === context.event.attack.target,
-                immediateEffect: AbilityHelper.immediateEffects.exhaust()
-            }
+            immediateEffect: AbilityHelper.immediateEffects.exhaust((context) => {
+                return { target: (context as TriggeredAbilityContext)?.event.attack.target };
+            })
         });
     }
 }

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -147,6 +147,7 @@ export enum TokenName {
 }
 
 export enum EventName {
+    MetaAttackSteps = 'metaAttackSteps',
     OnAbilityResolved = 'onAbilityResolved',
     OnAbilityResolverInitiated = 'onAbilityResolverInitiated',
     OnAddTokenToCard = 'onAddTokenToCard',

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -87,7 +87,8 @@ export enum Stage {
     Cost = 'cost',
     Effect = 'effect',
     PreTarget = 'preTarget',
-    Target = 'target'
+    Target = 'target',
+    Trigger = 'trigger'
 }
 
 export enum RelativePlayer {

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -127,6 +127,11 @@ class PlayerOrCardAbility {
             return 'cost';
         }
 
+        // we don't check whether a triggered ability has legal targets at the trigger stage, that's evaluated at ability resolution
+        if (context.stage === Stage.Trigger && this.isTriggeredAbility()) {
+            return '';
+        }
+
         // for actions, the only requirement to be legal to activate is that something changes game state. so if there's a resolvable cost, that's enough (see SWU 6.2.C)
         // TODO: add a card with an action that has no cost (e.g. Han red or Fennec) and confirm that the action is not legal to activate when there are no targets
         if (this.isAction()) {
@@ -277,6 +282,10 @@ class PlayerOrCardAbility {
 
     isAction() {
         return this.type === AbilityType.Action;
+    }
+
+    isTriggeredAbility() {
+        return this.type === AbilityType.Triggered;
     }
 
     /** Indicates whether a card is played as part of the resolution this ability */

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -151,6 +151,18 @@ class PlayerOrCardAbility {
         return '';
     }
 
+    hasAnyLegalEffects(context) {
+        if (this.gameSystem.length > 0 && this.checkGameActionsForPotential(context)) {
+            return true;
+        }
+
+        if (this.targetResolvers.length > 0 && this.canResolveSomeTarget(context)) {
+            return true;
+        }
+
+        return false;
+    }
+
     checkGameActionsForPotential(context) {
         return this.gameSystem.some((gameSystem) => gameSystem.hasLegalTarget(context));
     }

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -109,7 +109,7 @@ export default class TriggeredAbility extends CardAbility {
             source: this.card,
             player: player,
             ability: this,
-            stage: Stage.PreTarget
+            stage: Stage.Trigger
         });
     }
 

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -131,9 +131,10 @@ export class UpgradeCard extends UpgradeCardParent {
      * Adds an "attached card gains [X]" ability, where X is a keyword ability. You can provide a match function
      * to narrow down whether the effect is applied (for cases where the effect has conditions).
      */
-    protected addGainKeywordTargetingAttached(properties: IKeywordProperties) {
+    protected addGainKeywordTargetingAttached(properties: IKeywordProperties, gainCondition: (context: AbilityContext) => boolean = null) {
         this.addConstantAbilityTargetingAttached({
             title: 'Give keyword to the attached card',
+            condition: gainCondition,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(properties)
         });
     }

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -12,6 +12,7 @@ import { Card } from './Card';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import AbilityHelper from '../../AbilityHelper';
 import { WithStandardAbilitySetup } from './propertyMixins/StandardAbilitySetup';
+import { AbilityContext } from '../ability/AbilityContext';
 
 const UpgradeCardParent = WithPrintedPower(WithPrintedHp(WithCost(WithStandardAbilitySetup(InPlayCard))));
 
@@ -108,7 +109,7 @@ export class UpgradeCard extends UpgradeCardParent {
         this.addConstantAbility({
             title: properties.title,
             condition: properties.condition || (() => true),
-            matchTarget: (card, context) => card === this.parentCard && (!properties.matchTarget || properties.matchTarget(card, context)),
+            matchTarget: (card, context) => card === context.source.parentCard && (!properties.matchTarget || properties.matchTarget(card, context)),
             targetController: RelativePlayer.Any,   // this means that the effect continues to work even if the other player gains control of the upgrade
             ongoingEffect: properties.ongoingEffect
         });
@@ -118,9 +119,10 @@ export class UpgradeCard extends UpgradeCardParent {
      * Adds an "attached card gains [X]" ability, where X is a triggered ability. You can provide a match function
      * to narrow down whether the effect is applied (for cases where the effect has conditions).
      */
-    protected addGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityProps) {
+    protected addGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityProps, gainCondition: (context: AbilityContext) => boolean = null) {
         this.addConstantAbilityTargetingAttached({
             title: 'Give ability to the attached card',
+            condition: gainCondition,
             ongoingEffect: AbilityHelper.ongoingEffects.gainAbility(AbilityType.Triggered, properties)
         });
     }

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -43,6 +43,10 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
         }
 
         public addDamage(amount: number) {
+            if (!Contract.assertNotNullLikeOrNan(amount)) {
+                return;
+            }
+
             this.assertPropertyEnabled(this._damage, 'damage');
             if (
                 !Contract.assertNotNullLikeOrNan(this.damage) ||

--- a/server/game/core/cardSelector/BaseCardSelector.js
+++ b/server/game/core/cardSelector/BaseCardSelector.js
@@ -44,7 +44,7 @@ class BaseCardSelector {
             } else if (controllerProp === RelativePlayer.Opponent) {
                 return context.game.allCards.filter((card) => card.controller === context.player.opponent);
             }
-            return context.game.allCards.toArray();
+            return context.game.allCards;
         }
 
         let possibleCards = [];

--- a/server/game/core/gameSteps/AbilityResolver.js
+++ b/server/game/core/gameSteps/AbilityResolver.js
@@ -114,6 +114,8 @@ class AbilityResolver extends BaseStepWithPipeline {
             return;
         }
 
+        this.context.stage = Stage.PreTarget;
+
         // if there is no effect and no costs, we can safely skip ability resolution
         if (
             this.context.ability.meetsRequirements(this.context, ['cost']) !== '' &&
@@ -131,7 +133,6 @@ class AbilityResolver extends BaseStepWithPipeline {
             return;
         }
 
-        this.context.stage = Stage.PreTarget;
         if (!this.context.ability.cannotTargetFirst) {
             this.targetResults = this.context.ability.resolveTargets(this.context, this.passAbilityHandler);
         }

--- a/server/game/core/gameSteps/abilityWindow/TriggeredAbilityWindow.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggeredAbilityWindow.ts
@@ -175,14 +175,17 @@ export class TriggeredAbilityWindow extends BaseStep {
 
     private promptForNextAbilityToResolve() {
         const abilitiesToResolve = this.getCurrentlyResolvingAbilities();
-        const choices = abilitiesToResolve.map((context, index) => {
-            return { text: (context.ability as TriggeredAbility).title, method: 'resolveAbility', arg: context };
-        });
+
+        // TODO: need to optionally show additional details in the ability options for more complex situations, e.g. same ability triggered multiple times in the same window.
+        // (see forcedtriggeredabilitywindow.js in the L5R code for reference)
+        const choices = abilitiesToResolve.map((context) => (context.ability as TriggeredAbility).title);
+        const handlers = abilitiesToResolve.map((context) => () => this.resolveAbility(context));
 
         this.game.promptWithHandlerMenu(this.currentlyResolvingPlayer, {
             activePromptTitle: 'Choose an ability to resolve:',
             source: 'Choose Triggered Ability Resolution Order',
-            choices: choices
+            choices: choices,
+            handlers: handlers
         });
 
         this.game.promptForSelect(this.currentlyResolvingPlayer, Object.assign(this.getPromptForSelectProperties(), {
@@ -194,7 +197,7 @@ export class TriggeredAbilityWindow extends BaseStep {
     }
 
     protected getPromptForSelectProperties() {
-        return Object.assign({ location: WildcardLocation.Any }, this.getPromptProperties());
+        return Object.assign({ locationFilter: WildcardLocation.Any }, this.getPromptProperties());
     }
 
     private getPromptProperties() {
@@ -231,11 +234,6 @@ export class TriggeredAbilityWindow extends BaseStep {
         for (const abilityContext of abilitiesAvailableForPlayer) {
             if (!Contract.assertNotNullLike(abilityContext.source)) {
                 continue;
-            }
-
-            // TODO: fill out this implementation. see forcedtriggeredabilitywindow.js in the L5R code for reference
-            if (triggeringCards.has(abilityContext.source)) {
-                throw Error(`The card ${abilityContext.source} has had multiple abilities triggered in the same event window (or one ability triggered multiple times). This is not yet implemented.`);
             }
 
             triggeringCards.add(abilityContext.source);

--- a/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
+++ b/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
@@ -57,7 +57,6 @@ class HandlerMenuPrompt extends UiPrompt {
                     cardQuantities[card.id] = 1;
                 }
             });
-            // TODO: write our own uniq function so we can remove underscore and convert to TS
             let cards = this.getUniqueCardsById(this.properties.cards);
             buttons = cards.map((card) => {
                 let text = card.name;

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -49,7 +49,7 @@ export interface IAttackProperties extends ICardTargetSystemProperties {
  */
 export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
     public override readonly name = 'attack';
-    public override readonly eventName = EventName.Unnamed;
+    public override readonly eventName = EventName.MetaAttackSteps;
     protected override readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Unit, CardType.Base];
     protected override readonly defaultProperties: IAttackProperties = {
         targetCondition: () => true

--- a/server/game/gameSystems/ConditionalSystem.ts
+++ b/server/game/gameSystems/ConditionalSystem.ts
@@ -4,16 +4,15 @@ import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem
 
 export interface IConditionalSystemProperties extends IGameSystemProperties {
     condition: ((context: AbilityContext, properties: IConditionalSystemProperties) => boolean) | boolean;
-    trueGameAction: GameSystem;
-    falseGameAction: GameSystem;
+    trueImmediateEffect: GameSystem;
+    falseImmediateEffect: GameSystem;
 }
 
-/** @deprecated This was brought from L5R but has not yet been tested */
 export class ConditionalSystem extends GameSystem<IConditionalSystemProperties> {
     public override generatePropertiesFromContext(context: AbilityContext, additionalProperties = {}): IConditionalSystemProperties {
         const properties = super.generatePropertiesFromContext(context, additionalProperties);
-        properties.trueGameAction.setDefaultTargetFn(() => properties.target);
-        properties.falseGameAction.setDefaultTargetFn(() => properties.target);
+        properties.trueImmediateEffect.setDefaultTargetFn(() => properties.target);
+        properties.falseImmediateEffect.setDefaultTargetFn(() => properties.target);
         return properties;
     }
 
@@ -50,7 +49,7 @@ export class ConditionalSystem extends GameSystem<IConditionalSystemProperties> 
         if (typeof condition === 'function') {
             condition = condition(context, properties);
         }
-        return condition ? properties.trueGameAction : properties.falseGameAction;
+        return condition ? properties.trueImmediateEffect : properties.falseImmediateEffect;
     }
 
     // TODO: refactor GameSystem so this class doesn't need to override this method (it isn't called since we override hasLegalTarget)

--- a/server/game/gameSystems/DamageSystem.ts
+++ b/server/game/gameSystems/DamageSystem.ts
@@ -5,7 +5,7 @@ import * as EnumHelpers from '../core/utils/EnumHelpers';
 import { type ICardTargetSystemProperties, CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 
 export interface IDamageProperties extends ICardTargetSystemProperties {
-    amount?: number;
+    amount: number;
     isCombatDamage?: boolean;
 }
 

--- a/server/game/gameSystems/ExecuteHandlerSystem.ts
+++ b/server/game/gameSystems/ExecuteHandlerSystem.ts
@@ -8,7 +8,6 @@ export interface IExecuteHandlerSystemProperties extends IGameSystemProperties {
     hasTargetsChosenByInitiatingPlayer?: boolean;
 }
 
-// TODO: this is sometimes getting used as a no-op, see if we can add an explicit implementation for that
 /**
  * A {@link GameSystem} which executes a handler function
  * @override This was copied from L5R but has not been tested yet

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -40,6 +40,7 @@ import { MoveCardSystem, IMoveCardProperties } from './MoveCardSystem';
 // import { MoveTokenAction, MoveTokenProperties } from './MoveTokenAction';
 // import { MultipleContextActionProperties, MultipleContextGameAction } from './MultipleContextGameAction';
 // import { MultipleGameAction } from './MultipleGameAction';
+import { NoActionSystem, INoActionSystemProperties } from './NoActionSystem';
 // import { OpponentPutIntoPlayAction, OpponentPutIntoPlayProperties } from './OpponentPutIntoPlayAction';
 // import { PlaceCardUnderneathAction, PlaceCardUnderneathProperties } from './PlaceCardUnderneathAction';
 // import { PlayCardAction, PlayCardProperties } from './PlayCardAction';
@@ -265,8 +266,8 @@ export function drawSpecificCard(propertyFactory: PropsFactory<IDrawSpecificCard
 export function handler(propertyFactory: PropsFactory<IExecuteHandlerSystemProperties>): GameSystem {
     return new ExecuteHandlerSystem(propertyFactory);
 }
-export function noAction(): GameSystem {
-    return new ExecuteHandlerSystem({});
+export function noAction(propertyFactory: PropsFactory<INoActionSystemProperties> = {}): GameSystem {
+    return new NoActionSystem(propertyFactory);
 }
 export function replacementEffect(propertyFactory: PropsFactory<IReplacementEffectSystemProperties>): GameSystem {
     return new ReplacementEffectSystem(propertyFactory);

--- a/server/game/gameSystems/NoActionSystem.ts
+++ b/server/game/gameSystems/NoActionSystem.ts
@@ -1,0 +1,35 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import { GameSystem, type IGameSystemProperties } from '../core/gameSystem/GameSystem';
+import { Card } from '../core/card/Card';
+import { GameEvent } from '../core/event/GameEvent';
+
+export interface INoActionSystemProperties extends IGameSystemProperties {
+    hasLegalTarget?: boolean;
+}
+
+/**
+ * A {@link GameSystem} which executes a handler function
+ * @override This was copied from L5R but has not been tested yet
+ */
+export class NoActionSystem extends GameSystem<INoActionSystemProperties> {
+    protected override readonly defaultProperties: INoActionSystemProperties = {
+        hasLegalTarget: false
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public eventHandler(event, additionalProperties = {}): void {}
+
+    public override hasLegalTarget(context): boolean {
+        const { hasLegalTarget: allowTargetSelection } = this.generatePropertiesFromContext(context);
+        return allowTargetSelection;
+    }
+
+    public override canAffect(card: Card, context: AbilityContext): boolean {
+        const { hasLegalTarget: allowTargetSelection } = this.generatePropertiesFromContext(context);
+        return allowTargetSelection;
+    }
+
+    protected override isTargetTypeValid(target: any): boolean {
+        return true;
+    }
+}

--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -2,7 +2,7 @@ import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
 import CardSelector from '../core/cardSelector/CardSelector';
 import type BaseCardSelector from '../core/cardSelector/BaseCardSelector';
-import { CardType, EffectName, Location, RelativePlayer, TargetMode } from '../core/Constants';
+import { CardType, CardTypeFilter, EffectName, Location, RelativePlayer, TargetMode } from '../core/Constants';
 import { type ICardTargetSystemProperties, CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type { GameSystem } from '../core/gameSystem/GameSystem';
 import type { GameEvent } from '../core/event/GameEvent';
@@ -10,7 +10,7 @@ import type { GameEvent } from '../core/event/GameEvent';
 export interface ISelectCardProperties extends ICardTargetSystemProperties {
     activePromptTitle?: string;
     player?: RelativePlayer;
-    cardType?: CardType | CardType[];
+    cardTypeFilter?: CardTypeFilter | CardTypeFilter[];
     controller?: RelativePlayer;
     locationFilter?: Location | Location[];
     cardCondition?: (card: Card, context: AbilityContext) => boolean;

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -388,10 +388,14 @@ var customMatchers = {
     },
     toHavePassAbilityPrompt: function () {
         return {
-            compare: function (player) {
+            compare: function (player, abilityText) {
                 var result = {};
-                const passPromptText = 'Do you want to trigger this ability or pass?';
-                var currentPrompt = player.currentPrompt();
+
+                if (abilityText == null) {
+                    throw new Error('toHavePassAbilityPrompt requires an abilityText parameter');
+                }
+
+                const passPromptText = `Trigger the ability '${abilityText}' or pass`;
                 result.pass = player.hasPrompt(passPromptText);
 
                 if (result.pass) {

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -41,7 +41,7 @@ var customMatchers = {
                 if (result.pass) {
                     result.message = `Expected ${actual.name} not to have prompt '${expected}' but it did.`;
                 } else {
-                    result.message = `Expected ${actual.name} to have prompt '${expected}' but the prompt is:\n${formatPrompt(actual.currentPrompt(), actual.currentActionTargets)}.`;
+                    result.message = `Expected ${actual.name} to have prompt '${expected}' but the prompt is:\n${formatPrompt(actual.currentPrompt(), actual.currentActionTargets)}`;
                 }
 
                 return result;

--- a/test/server/cards/01_SOR/DeathTrooper.spec.js
+++ b/test/server/cards/01_SOR/DeathTrooper.spec.js
@@ -20,7 +20,7 @@ describe('Death Trooper', function() {
                 // Play Death Trooper
                 this.player1.clickCard(this.deathTrooper);
                 expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.deathTrooper]);
-                expect(this.player1).not.toHavePassAbilityPrompt();
+                expect(this.player1).not.toHavePassAbilityPrompt('Deal 2 damage to a friendly ground unit and an enemy ground unit');
             });
 
             it('can only target ground units & can damage itself', function () {
@@ -29,7 +29,7 @@ describe('Death Trooper', function() {
 
                 // Choose Friendly
                 expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.deathTrooper]);
-                expect(this.player1).not.toHavePassAbilityPrompt();
+                expect(this.player1).not.toHavePassAbilityPrompt('Deal 2 damage to a friendly ground unit and an enemy ground unit');
                 this.player1.clickCard(this.deathTrooper);
 
                 // Choose Enemy
@@ -46,7 +46,7 @@ describe('Death Trooper', function() {
 
                 // Choose Friendly
                 expect(this.player1).toBeAbleToSelectExactly([this.pykeSentinel, this.deathTrooper]);
-                expect(this.player1).not.toHavePassAbilityPrompt();
+                expect(this.player1).not.toHavePassAbilityPrompt('Deal 2 damage to a friendly ground unit and an enemy ground unit');
                 this.player1.clickCard(this.deathTrooper);
                 expect(this.deathTrooper.damage).toEqual(2);
             });

--- a/test/server/cards/01_SOR/FallenLightsaber.spec.js
+++ b/test/server/cards/01_SOR/FallenLightsaber.spec.js
@@ -1,0 +1,95 @@
+describe('Fallen Lightsaber', function() {
+    integration(function() {
+        describe('Fallen Lightsaber\'s ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{ card: 'guardian-of-the-whills', upgrades: ['fallen-lightsaber'] }, 'battlefield-marine'],
+                    },
+                    player2: {
+                        groundArena: ['snowspeeder', 'wampa'],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+            });
+
+            it('should deal 1 damage to all enemy ground units on attack when attached to a Force unit', function () {
+                this.player1.clickCard(this.guardianOfTheWhills);
+                this.player1.clickCard(this.p2Base);
+
+                expect(this.p2Base.damage).toBe(5);
+                expect(this.snowspeeder.damage).toBe(1);
+                expect(this.wampa.damage).toBe(1);
+                expect(this.cartelSpacer.damage).toBe(0);
+                expect(this.p1Base.damage).toBe(0);
+                expect(this.guardianOfTheWhills.damage).toBe(0);
+                expect(this.battlefieldMarine.damage).toBe(0);
+
+                // second attack with no saber to confirm the effect is gone
+                this.fallenLightsaber.unattach();
+                this.player1.moveCard(this.fallenLightsaber, 'discard');
+                this.guardianOfTheWhills.exhausted = false;
+                this.player2.passAction();
+
+                this.player1.clickCard(this.guardianOfTheWhills);
+                this.player1.clickCard(this.p2Base);
+
+                expect(this.p2Base.damage).toBe(7);
+                expect(this.snowspeeder.damage).toBe(1);
+                expect(this.wampa.damage).toBe(1);
+                expect(this.cartelSpacer.damage).toBe(0);
+                expect(this.p1Base.damage).toBe(0);
+                expect(this.guardianOfTheWhills.damage).toBe(0);
+                expect(this.battlefieldMarine.damage).toBe(0);
+            });
+        });
+
+        describe('Fallen Lightsaber\'s ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{ card: 'battlefield-marine', upgrades: ['fallen-lightsaber'] }, 'atst'],
+                    },
+                    player2: {
+                        groundArena: ['snowspeeder', 'wampa'],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+            });
+
+            it('should deal 1 damage to all enemy ground units on attack when attached to a Force unit', function () {
+                this.player1.clickCard(this.battlefieldMarine);
+                this.player1.clickCard(this.p2Base);
+
+                expect(this.p2Base.damage).toBe(6);
+                expect(this.snowspeeder.damage).toBe(0);
+                expect(this.wampa.damage).toBe(0);
+                expect(this.cartelSpacer.damage).toBe(0);
+                expect(this.p1Base.damage).toBe(0);
+                expect(this.atst.damage).toBe(0);
+                expect(this.battlefieldMarine.damage).toBe(0);
+            });
+        });
+
+        describe('Fallen Lightsaber', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['fallen-lightsaber'],
+                        groundArena: ['snowspeeder', 'battlefield-marine']
+                    },
+                    player2: {
+                    }
+                });
+            });
+
+            it('should not be playable on vehicles', function () {
+                this.player1.clickCard(this.fallenLightsaber);
+                expect(this.battlefieldMarine.upgrades).toContain(this.fallenLightsaber);
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/JedhaAgitator.spec.js
+++ b/test/server/cards/01_SOR/JedhaAgitator.spec.js
@@ -1,27 +1,27 @@
 describe('Jedha Agitator', function() {
     integration(function() {
-        // describe('Jedha Agitator\'s on attack ability', function() {
-        //     beforeEach(function () {
-        //         this.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 groundArena: ['jedha-agitator'],
-        //             },
-        //             player2: {
-        //                 groundArena: ['wampa'],
-        //                 spaceArena: ['cartel-spacer']
-        //             }
-        //         });
-        //     });
+        describe('Jedha Agitator\'s on attack ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['jedha-agitator'],
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+            });
 
-        //     it('should do nothing if no leader is deployed', function () {
-        //         this.player1.clickCard(this.jedhaAgitator);
-        //         this.player1.clickCard(this.p2Base);
-        //         expect(this.jedhaAgitator.exhausted).toBe(true);
+            it('should do nothing if no leader is deployed', function () {
+                this.player1.clickCard(this.jedhaAgitator);
+                this.player1.clickCard(this.p2Base);
+                expect(this.jedhaAgitator.exhausted).toBe(true);
 
-        //         expect(this.player2).toBeActivePlayer();
-        //     });
-        // });
+                expect(this.player2).toBeActivePlayer();
+            });
+        });
 
         describe('Jedha Agitator\'s on attack ability', function() {
             beforeEach(function () {
@@ -40,6 +40,7 @@ describe('Jedha Agitator', function() {
             });
 
             it('should deal 2 damage to a ground unit or base if a leader is deployed', function () {
+                // ************** CASE 1: deal damage to a ground unit **************
                 this.player1.clickCard(this.jedhaAgitator);
                 this.player1.clickCard(this.p2Base);
 
@@ -49,10 +50,34 @@ describe('Jedha Agitator', function() {
 
                 this.player1.clickPrompt('If you control a leader unit, deal 2 damage to a ground unit or base');
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.jedhaAgitator, this.battlefieldMarine, this.p1Base, this.p2Base, this.bobaFett]);
-                this.player1.clickCard(this.battlefieldMarine);
-                expect(this.battlefieldMarine.damage).toBe(2);
+                this.player1.clickCard(this.wampa);
+                expect(this.wampa.damage).toBe(2);
+                expect(this.p2Base.damage).toBe(2);
 
                 expect(this.player2).toBeActivePlayer();
+                this.player2.passAction();
+                this.jedhaAgitator.exhausted = false;
+
+                // ************** CASE 2: deal damage to base **************
+                this.player1.clickCard(this.jedhaAgitator);
+                this.player1.clickCard(this.p2Base);
+                this.player1.clickPrompt('If you control a leader unit, deal 2 damage to a ground unit or base');
+                this.player1.clickCard(this.p1Base);
+                expect(this.jedhaAgitator.exhausted).toBe(true);
+                expect(this.p1Base.damage).toBe(2);
+                expect(this.p2Base.damage).toBe(4);
+
+                this.player2.passAction();
+                this.jedhaAgitator.exhausted = false;
+
+                // ************** CASE 3: deal damage to self **************
+                this.player1.clickCard(this.jedhaAgitator);
+                this.player1.clickCard(this.p2Base);
+                this.player1.clickPrompt('If you control a leader unit, deal 2 damage to a ground unit or base');
+                this.player1.clickCard(this.jedhaAgitator);
+                expect(this.jedhaAgitator).toBeInLocation('discard');
+                expect(this.p1Base.damage).toBe(2);
+                expect(this.p2Base.damage).toBe(4);     // attack did not resolve
             });
         });
     });

--- a/test/server/cards/01_SOR/JedhaAgitator.spec.js
+++ b/test/server/cards/01_SOR/JedhaAgitator.spec.js
@@ -1,11 +1,36 @@
 describe('Jedha Agitator', function() {
     integration(function() {
+        // describe('Jedha Agitator\'s on attack ability', function() {
+        //     beforeEach(function () {
+        //         this.setupTest({
+        //             phase: 'action',
+        //             player1: {
+        //                 groundArena: ['jedha-agitator'],
+        //             },
+        //             player2: {
+        //                 groundArena: ['wampa'],
+        //                 spaceArena: ['cartel-spacer']
+        //             }
+        //         });
+        //     });
+
+        //     it('should do nothing if no leader is deployed', function () {
+        //         this.player1.clickCard(this.jedhaAgitator);
+        //         this.player1.clickCard(this.p2Base);
+        //         expect(this.jedhaAgitator.exhausted).toBe(true);
+
+        //         expect(this.player2).toBeActivePlayer();
+        //     });
+        // });
+
         describe('Jedha Agitator\'s on attack ability', function() {
             beforeEach(function () {
                 this.setupTest({
                     phase: 'action',
                     player1: {
-                        groundArena: ['jedha-agitator'],
+                        groundArena: ['jedha-agitator', 'battlefield-marine'],
+                        spaceArena: ['tieln-fighter'],
+                        leader: { card: 'boba-fett#daimyo', deployed: true }
                     },
                     player2: {
                         groundArena: ['wampa'],
@@ -14,10 +39,18 @@ describe('Jedha Agitator', function() {
                 });
             });
 
-            it('should do nothing if no leader is deployed', function () {
+            it('should deal 2 damage to a ground unit or base if a leader is deployed', function () {
                 this.player1.clickCard(this.jedhaAgitator);
                 this.player1.clickCard(this.p2Base);
+
+                expect(this.player1).toHaveEnabledPromptButton('If you control a leader unit, deal 2 damage to a ground unit or base');
+                expect(this.player1).toHaveEnabledPromptButton('Saboteur: defeat all shields');
                 expect(this.jedhaAgitator.exhausted).toBe(true);
+
+                this.player1.clickPrompt('If you control a leader unit, deal 2 damage to a ground unit or base');
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.jedhaAgitator, this.battlefieldMarine, this.p1Base, this.p2Base, this.bobaFett]);
+                this.player1.clickCard(this.battlefieldMarine);
+                expect(this.battlefieldMarine.damage).toBe(2);
 
                 expect(this.player2).toBeActivePlayer();
             });

--- a/test/server/cards/01_SOR/JedhaAgitator.spec.js
+++ b/test/server/cards/01_SOR/JedhaAgitator.spec.js
@@ -18,7 +18,6 @@ describe('Jedha Agitator', function() {
                 this.player1.clickCard(this.jedhaAgitator);
                 this.player1.clickCard(this.p2Base);
                 expect(this.jedhaAgitator.exhausted).toBe(true);
-                expect(this.player1).toHavePrompt('bleh');
 
                 expect(this.player2).toBeActivePlayer();
             });

--- a/test/server/cards/01_SOR/JedhaAgitator.spec.js
+++ b/test/server/cards/01_SOR/JedhaAgitator.spec.js
@@ -1,0 +1,27 @@
+describe('Jedha Agitator', function() {
+    integration(function() {
+        describe('Jedha Agitator\'s on attack ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['jedha-agitator'],
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+            });
+
+            it('should do nothing if no leader is deployed', function () {
+                this.player1.clickCard(this.jedhaAgitator);
+                this.player1.clickCard(this.p2Base);
+                expect(this.jedhaAgitator.exhausted).toBe(true);
+                expect(this.player1).toHavePrompt('bleh');
+
+                expect(this.player2).toBeActivePlayer();
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/JedhaAgitator.spec.js
+++ b/test/server/cards/01_SOR/JedhaAgitator.spec.js
@@ -30,7 +30,7 @@ describe('Jedha Agitator', function() {
                     player1: {
                         groundArena: ['jedha-agitator', 'battlefield-marine'],
                         spaceArena: ['tieln-fighter'],
-                        leader: { card: 'boba-fett#daimyo', deployed: true }
+                        leader: { card: 'hunter#outcast-sergeant', deployed: true }
                     },
                     player2: {
                         groundArena: ['wampa'],
@@ -49,7 +49,7 @@ describe('Jedha Agitator', function() {
                 expect(this.jedhaAgitator.exhausted).toBe(true);
 
                 this.player1.clickPrompt('If you control a leader unit, deal 2 damage to a ground unit or base');
-                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.jedhaAgitator, this.battlefieldMarine, this.p1Base, this.p2Base, this.bobaFett]);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.jedhaAgitator, this.battlefieldMarine, this.p1Base, this.p2Base, this.hunter]);
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.damage).toBe(2);
                 expect(this.p2Base.damage).toBe(2);

--- a/test/server/cards/01_SOR/VadersLightsaber.spec.js
+++ b/test/server/cards/01_SOR/VadersLightsaber.spec.js
@@ -1,0 +1,31 @@
+describe('Vader\'s Lightsaber', function() {
+    integration(function() {
+        describe('Vader\'s Lightsaber\'s ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['vaders-lightsaber'],
+                        groundArena: ['darth-vader#commanding-the-first-legion'],
+                        spaceArena: ['tieln-fighter'],
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['cartel-spacer'],
+                    }
+                });
+            });
+
+            it('should deal 4 damage to a ground unit when attached to Darth Vader unit', function () {
+                this.player1.clickCard(this.vadersLightsaber);
+                this.player1.clickCard(this.darthVader);
+
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.darthVader]);
+                expect(this.player1).not.toHavePassAbilityPrompt();
+
+                this.player1.clickCard(this.wampa);
+                expect(this.wampa.damage).toBe(4);
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/VadersLightsaber.spec.js
+++ b/test/server/cards/01_SOR/VadersLightsaber.spec.js
@@ -16,15 +16,58 @@ describe('Vader\'s Lightsaber', function() {
                 });
             });
 
-            it('should deal 4 damage to a ground unit when attached to Darth Vader unit', function () {
+            it('should deal 4 damage to a ground unit when attached to the Darth Vader unit', function () {
                 this.player1.clickCard(this.vadersLightsaber);
+                expect(this.player1).toBeAbleToSelectExactly([this.darthVader, this.wampa]);    // cannot attach to vehicles
                 this.player1.clickCard(this.darthVader);
 
+                expect(this.darthVader).toHaveExactUpgradeNames(['vaders-lightsaber']);
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.darthVader]);
                 expect(this.player1).not.toHavePassAbilityPrompt();
 
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.damage).toBe(4);
+
+                expect(this.player2).toBeActivePlayer();
+            });
+
+            it('should do nothing when attached to a unit that is not Darth Vader', function () {
+                this.player1.clickCard(this.vadersLightsaber);
+                this.player1.clickCard(this.wampa);
+
+                expect(this.wampa).toHaveExactUpgradeNames(['vaders-lightsaber']);
+                expect(this.player2).toBeActivePlayer();
+            });
+        });
+
+        describe('Vader\'s Lightsaber\'s ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['vaders-lightsaber'],
+                        spaceArena: ['tieln-fighter'],
+                        leader: { card: 'darth-vader#dark-lord-of-the-sith', deployed: true },
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['cartel-spacer'],
+                    }
+                });
+            });
+
+            it('should deal 4 damage to a ground unit when attached to the Darth Vader leader', function () {
+                this.player1.clickCard(this.vadersLightsaber);
+                this.player1.clickCard(this.darthVader);
+
+                expect(this.darthVader).toHaveExactUpgradeNames(['vaders-lightsaber']);
+                expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.darthVader]);
+                expect(this.player1).not.toHavePassAbilityPrompt();
+
+                this.player1.clickCard(this.wampa);
+                expect(this.wampa.damage).toBe(4);
+
+                expect(this.player2).toBeActivePlayer();
             });
         });
     });

--- a/test/server/cards/01_SOR/VadersLightsaber.spec.js
+++ b/test/server/cards/01_SOR/VadersLightsaber.spec.js
@@ -21,9 +21,13 @@ describe('Vader\'s Lightsaber', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.darthVader, this.wampa]);    // cannot attach to vehicles
                 this.player1.clickCard(this.darthVader);
 
+                // TODO: ideally the pass option would work like it does for target resolvers, where we just add a "Pass"
+                // button to the target selection window. Need to change it so that's possible with SelectCard.
+
                 expect(this.darthVader).toHaveExactUpgradeNames(['vaders-lightsaber']);
+                expect(this.player1).toHavePassAbilityPrompt('Deal 4 damage to a ground unit');
+                this.player1.clickPrompt('Deal 4 damage to a ground unit');
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.darthVader]);
-                expect(this.player1).not.toHavePassAbilityPrompt();
 
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.damage).toBe(4);
@@ -61,8 +65,9 @@ describe('Vader\'s Lightsaber', function() {
                 this.player1.clickCard(this.darthVader);
 
                 expect(this.darthVader).toHaveExactUpgradeNames(['vaders-lightsaber']);
+                expect(this.player1).toHavePassAbilityPrompt('Deal 4 damage to a ground unit');
+                this.player1.clickPrompt('Deal 4 damage to a ground unit');
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.darthVader]);
-                expect(this.player1).not.toHavePassAbilityPrompt();
 
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.damage).toBe(4);


### PR DESCRIPTION
Rounded out the ConditionalSystem so that it could be used to support most cases of the word "if" in card abilities (the primary exception being "if you do", which will require special logic).

Implemented a few cards to demonstrate how to implement the word "if" when used in:
- Normal triggered abilities
- Triggered abilities on attachments
- Constant abilities on attachments

Examples for other cases (particularly actions) will come in future PRs but the core functionality should be the same for all.

Also did some improvements to engine components to resolve issues found during testing, mainly in the TriggeredAbilityWindow. The fact that it would error out in a situation where there are multiple triggers on the same unit became a blocker, so for now we are just presenting every ability by text name regardless of any additional context. This will need to be improved eventually, but for the simple cases that come up in tests it's fine for now.