### PR TITLE
Vader's lightsaber targeting hotfix

### DIFF
--- a/server/game/cards/01_SOR/VadersLightsaber.ts
+++ b/server/game/cards/01_SOR/VadersLightsaber.ts
@@ -24,19 +24,16 @@ export default class VadersLightsaber extends UpgradeCard {
         this.addWhenPlayedAbility({
             title: 'Deal 4 damage to a ground unit',
             optional: true,
-            immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => context.source.parentCard?.title === 'Darth Vader',
-                trueImmediateEffect: this.vaderLightsaberAbility(),
-                falseImmediateEffect: AbilityHelper.immediateEffects.noAction()
-            })
-        });
-    }
+            targetResolver: {
+                locationFilter: Location.GroundArena,
+                cardTypeFilter: WildcardCardType.Unit,
+                immediateEffect: AbilityHelper.immediateEffects.conditional({
+                    condition: (context) => context.source.parentCard?.title === 'Darth Vader',
+                    trueImmediateEffect: AbilityHelper.immediateEffects.damage({ amount: 4 }),
+                    falseImmediateEffect: AbilityHelper.immediateEffects.noAction()
+                })
+            }
 
-    private vaderLightsaberAbility() {
-        return AbilityHelper.immediateEffects.selectCard({
-            locationFilter: Location.GroundArena,
-            cardTypeFilter: WildcardCardType.Unit,
-            innerSystem: AbilityHelper.immediateEffects.damage({ amount: 4 })
         });
     }
 }

--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -29,6 +29,10 @@ export interface ISelectCardProperties extends ICardTargetSystemProperties {
     effectArgs?: (context) => string[];
 }
 
+
+// TODO: ideally the pass option would work like it does for target resolvers, where we just add a "Pass"
+// button to the target selection window. Need to change it so that's possible with SelectCard.
+
 /**
  * A wrapper system for adding a target selection prompt around the execution the wrapped system.
  * Functions the same as a targetResolver and used in situations where one can't be created (e.g., costs).

--- a/test/server/cards/01_SOR/VadersLightsaber.spec.js
+++ b/test/server/cards/01_SOR/VadersLightsaber.spec.js
@@ -21,13 +21,9 @@ describe('Vader\'s Lightsaber', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.darthVader, this.wampa]);    // cannot attach to vehicles
                 this.player1.clickCard(this.darthVader);
 
-                // TODO: ideally the pass option would work like it does for target resolvers, where we just add a "Pass"
-                // button to the target selection window. Need to change it so that's possible with SelectCard.
-
                 expect(this.darthVader).toHaveExactUpgradeNames(['vaders-lightsaber']);
-                expect(this.player1).toHavePassAbilityPrompt('Deal 4 damage to a ground unit');
-                this.player1.clickPrompt('Deal 4 damage to a ground unit');
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.darthVader]);
+                expect(this.player1).toHaveEnabledPromptButton('Pass ability');
 
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.damage).toBe(4);
@@ -65,9 +61,8 @@ describe('Vader\'s Lightsaber', function() {
                 this.player1.clickCard(this.darthVader);
 
                 expect(this.darthVader).toHaveExactUpgradeNames(['vaders-lightsaber']);
-                expect(this.player1).toHavePassAbilityPrompt('Deal 4 damage to a ground unit');
-                this.player1.clickPrompt('Deal 4 damage to a ground unit');
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.darthVader]);
+                expect(this.player1).toHaveEnabledPromptButton('Pass ability');
 
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.damage).toBe(4);


### PR DESCRIPTION
Realized that we could get targeting to work correctly with a TargetResolver. Did a quick fix so that the "Pass" option will now appear correctly as expected (though we still need a fix for SelectCard at some point).