### PR TITLE
Refactor to support better type inference

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -15,12 +15,12 @@ import { IInitiateAttackProperties } from './gameSystems/InitiateAttackSystem';
 // ********************************************** EXPORTED TYPES **********************************************
 
 /** Interface definition for addTriggeredAbility */
-export type ITriggeredAbilityProps = ITriggeredAbilityWhenProps | ITriggeredAbilityAggregateWhenProps;
-export type IReplacementEffectAbilityProps = IReplacementEffectAbilityWhenProps | IReplacementEffectAbilityAggregateWhenProps;
+export type ITriggeredAbilityProps<TSource extends Card = Card> = ITriggeredAbilityWhenProps<TSource> | ITriggeredAbilityAggregateWhenProps<TSource>;
+export type IReplacementEffectAbilityProps<TSource extends Card = Card> = IReplacementEffectAbilityWhenProps<TSource> | IReplacementEffectAbilityAggregateWhenProps<TSource>;
 
 /** Interface definition for addActionAbility */
-export type IActionAbilityProps<Source = any> = Exclude<IAbilityPropsWithSystems<AbilityContext<Source>>, 'optional'> & {
-    condition?: (context?: AbilityContext<Source>) => boolean;
+export type IActionAbilityProps<TSource extends Card = Card> = Exclude<IAbilityPropsWithSystems<AbilityContext<TSource>>, 'optional'> & {
+    condition?: (context?: AbilityContext<TSource>) => boolean;
 
     /**
      * If true, any player can trigger the ability. If false, only the card's controller can trigger it.
@@ -30,13 +30,13 @@ export type IActionAbilityProps<Source = any> = Exclude<IAbilityPropsWithSystems
 }
 
 /** Interface definition for addConstantAbility */
-export interface IConstantAbilityProps<Source = any> {
+export interface IConstantAbilityProps<TSource extends Card = Card> {
     title: string;
     sourceLocationFilter?: LocationFilter | LocationFilter[];
     /** A handler to enable or disable the ability's effects depending on game context */
-    condition?: (context: AbilityContext<Source>) => boolean;
+    condition?: (context: AbilityContext<TSource>) => boolean;
     /** A handler to determine if a specific card is impacted by the ability effect */
-    matchTarget?: (card: Card, context?: AbilityContext<Source>) => boolean;
+    matchTarget?: (card: Card, context?: AbilityContext<TSource>) => boolean;
     targetController?: RelativePlayer;
     targetLocationFilter?: LocationFilter;
     targetCardTypeFilter?: CardTypeFilter | CardTypeFilter[];
@@ -50,7 +50,7 @@ export interface IConstantAbilityProps<Source = any> {
 }
 
 // exported for use in situations where we need to exclude "when" and "aggregateWhen"
-export type ITriggeredAbilityBaseProps = IAbilityPropsWithSystems<TriggeredAbilityContext> & {
+export type ITriggeredAbilityBaseProps<TSource extends Card = Card> = IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>> & {
     collectiveTrigger?: boolean;
     targetResolver?: ITriggeredAbilityTargetResolver;
     targetResolvers?: ITriggeredAbilityTargetsResolver;
@@ -59,13 +59,13 @@ export type ITriggeredAbilityBaseProps = IAbilityPropsWithSystems<TriggeredAbili
 }
 
 /** Interface definition for setEventAbility */
-export type IEventAbilityProps<Source = any> = IAbilityPropsWithSystems<AbilityContext<Source>>;
+export type IEventAbilityProps<TSource extends Card = Card> = IAbilityPropsWithSystems<AbilityContext<TSource>>;
 
 /** Interface definition for setEpicActionAbility */
-export type IEpicActionProps<Source = any> = Exclude<IAbilityPropsWithSystems<AbilityContext<Source>>, 'cost' | 'limit' | 'handler'>;
+export type IEpicActionProps<TSource extends Card = Card> = Exclude<IAbilityPropsWithSystems<AbilityContext<TSource>>, 'cost' | 'limit' | 'handler'>;
 
 
-interface IReplacementEffectAbilityBaseProps extends Omit<ITriggeredAbilityBaseProps,
+interface IReplacementEffectAbilityBaseProps<TSource extends Card = Card> extends Omit<ITriggeredAbilityBaseProps<TSource>,
         'immediateEffect' | 'targetResolver' | 'targetResolvers' | 'handler'
 > {
     replaceWith: IReplacementEffectSystemProperties
@@ -103,16 +103,16 @@ export type EffectArg =
     | { id: string; label: string; name: string; facedown: boolean; type: CardType }
     | EffectArg[];
 
-export type WhenType = {
-        [EventNameValue in EventName]?: (event: any, context?: TriggeredAbilityContext) => boolean;
+export type WhenType<TSource extends Card = Card> = {
+        [EventNameValue in EventName]?: (event: any, context?: TriggeredAbilityContext<TSource>) => boolean;
     };
 
 // ********************************************** INTERNAL TYPES **********************************************
-type ITriggeredAbilityWhenProps = ITriggeredAbilityBaseProps & {
-    when: WhenType;
+type ITriggeredAbilityWhenProps<TSource extends Card> = ITriggeredAbilityBaseProps<TSource> & {
+    when: WhenType<TSource>;
 }
 
-type ITriggeredAbilityAggregateWhenProps = ITriggeredAbilityBaseProps & {
+type ITriggeredAbilityAggregateWhenProps<TSource extends Card> = ITriggeredAbilityBaseProps<TSource> & {
     aggregateWhen: (events: GameEvent[], context: TriggeredAbilityContext) => boolean;
 }
 
@@ -162,7 +162,7 @@ interface IAbilityPropsWithInitiateAttack<Context> extends IAbilityProps<Context
      * Can either be an {@link IInitiateAttackProperties} property object or a function that creates one from
      * an {@link AbilityContext}.
      */
-    initiateAttack?: IInitiateAttackProperties | ((context: AbilityContext) => IInitiateAttackProperties);
+    initiateAttack?: IInitiateAttackProperties | ((context: Context) => IInitiateAttackProperties);
 }
 
 type IAbilityPropsWithSystems<Context> =
@@ -172,11 +172,11 @@ type IAbilityPropsWithSystems<Context> =
     IAbilityPropsWithTargetResolvers<Context> |
     IAbilityPropsWithHandler<Context>;
 
-interface IReplacementEffectAbilityWhenProps extends IReplacementEffectAbilityBaseProps {
-    when: WhenType;
+interface IReplacementEffectAbilityWhenProps<TSource extends Card> extends IReplacementEffectAbilityBaseProps<TSource> {
+    when: WhenType<TSource>;
 }
 
-interface IReplacementEffectAbilityAggregateWhenProps extends IReplacementEffectAbilityBaseProps {
+interface IReplacementEffectAbilityAggregateWhenProps<TSource extends Card> extends IReplacementEffectAbilityBaseProps<TSource> {
     aggregateWhen: (events: GameEvent[], context: TriggeredAbilityContext) => boolean;
 }
 

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -8,6 +8,7 @@ import type { GameEvent } from './core/event/GameEvent';
 import type { IActionTargetResolver, IActionTargetsResolver, ITriggeredAbilityTargetResolver, ITriggeredAbilityTargetsResolver } from './TargetInterfaces';
 import { IReplacementEffectSystemProperties } from './gameSystems/ReplacementEffectSystem';
 import { IInitiateAttackProperties } from './gameSystems/InitiateAttackSystem';
+import { MetaSystem } from './core/gameSystem/MetaSystem';
 
 // allow block comments without spaces so we can have compact jsdoc descriptions in this file
 /* eslint @stylistic/js/lines-around-comment: off */
@@ -52,8 +53,8 @@ export interface IConstantAbilityProps<TSource extends Card = Card> {
 // exported for use in situations where we need to exclude "when" and "aggregateWhen"
 export type ITriggeredAbilityBaseProps<TSource extends Card = Card> = IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>> & {
     collectiveTrigger?: boolean;
-    targetResolver?: ITriggeredAbilityTargetResolver;
-    targetResolvers?: ITriggeredAbilityTargetsResolver;
+    targetResolver?: ITriggeredAbilityTargetResolver<TriggeredAbilityContext<TSource>>;
+    targetResolvers?: ITriggeredAbilityTargetsResolver<TriggeredAbilityContext<TSource>>;
     handler?: (context: TriggeredAbilityContext) => void;
     then?: ((context?: TriggeredAbilityContext) => IAbilityProps<TriggeredAbilityContext>) | IAbilityProps<TriggeredAbilityContext>;
 }
@@ -119,7 +120,7 @@ type ITriggeredAbilityAggregateWhenProps<TSource extends Card> = ITriggeredAbili
 // TODO: since many of the files that use this are JS, it's hard to know if it's fully correct.
 // for example, there's ambiguity between IAbilityProps and ITriggeredAbilityProps at the level of PlayerOrCardAbility
 /** Base interface for triggered and action ability definitions */
-interface IAbilityProps<Context> {
+interface IAbilityProps<TContext extends AbilityContext> {
     title: string;
     locationFilter?: LocationFilter | LocationFilter[];
     cost?: any;
@@ -135,42 +136,42 @@ interface IAbilityProps<Context> {
     printedAbility?: boolean;
     cannotTargetFirst?: boolean;
     effect?: string;
-    effectArgs?: EffectArg | ((context: Context) => EffectArg);
-    then?: ((context?: AbilityContext) => IAbilityPropsWithSystems<Context>) | IAbilityPropsWithSystems<Context>;
+    effectArgs?: EffectArg | ((context: TContext) => EffectArg);
+    then?: ((context?: AbilityContext) => IAbilityPropsWithSystems<TContext>) | IAbilityPropsWithSystems<TContext>;
 }
 
-interface IAbilityPropsWithTargetResolver<Context> extends IAbilityProps<Context> {
-    targetResolver: IActionTargetResolver;
+interface IAbilityPropsWithTargetResolver<TContext extends AbilityContext> extends IAbilityProps<TContext> {
+    targetResolver: IActionTargetResolver<TContext>;
 }
 
-interface IAbilityPropsWithTargetResolvers<Context> extends IAbilityProps<Context> {
-    targetResolvers: IActionTargetsResolver;
+interface IAbilityPropsWithTargetResolvers<TContext extends AbilityContext> extends IAbilityProps<TContext> {
+    targetResolvers: IActionTargetsResolver<TContext>;
 }
 
-interface IAbilityPropsWithImmediateEffect<Context> extends IAbilityProps<Context> {
-    immediateEffect: GameSystem;
+interface IAbilityPropsWithImmediateEffect<TContext extends AbilityContext> extends IAbilityProps<TContext> {
+    immediateEffect: GameSystem | MetaSystem<TContext>;
 }
 
-interface IAbilityPropsWithHandler<Context> extends IAbilityProps<Context> {
-    handler: (context: Context) => void;
+interface IAbilityPropsWithHandler<TContext extends AbilityContext> extends IAbilityProps<TContext> {
+    handler: (context: TContext) => void;
 }
 
-interface IAbilityPropsWithInitiateAttack<Context> extends IAbilityProps<Context> {
+interface IAbilityPropsWithInitiateAttack<TContext extends AbilityContext> extends IAbilityProps<TContext> {
     /**
      * Indicates that an attack should be triggered from a friendly unit.
      * Shorthand for `AbilityHelper.immediateEffects.attack(AttackSelectionMode.SelectAttackerAndTarget)`.
      * Can either be an {@link IInitiateAttackProperties} property object or a function that creates one from
      * an {@link AbilityContext}.
      */
-    initiateAttack?: IInitiateAttackProperties | ((context: Context) => IInitiateAttackProperties);
+    initiateAttack?: IInitiateAttackProperties | ((context: TContext) => IInitiateAttackProperties);
 }
 
-type IAbilityPropsWithSystems<Context> =
-    IAbilityPropsWithImmediateEffect<Context> |
-    IAbilityPropsWithInitiateAttack<Context> |
-    IAbilityPropsWithTargetResolver<Context> |
-    IAbilityPropsWithTargetResolvers<Context> |
-    IAbilityPropsWithHandler<Context>;
+type IAbilityPropsWithSystems<TContext extends AbilityContext> =
+    IAbilityPropsWithImmediateEffect<TContext> |
+    IAbilityPropsWithInitiateAttack<TContext> |
+    IAbilityPropsWithTargetResolver<TContext> |
+    IAbilityPropsWithTargetResolvers<TContext> |
+    IAbilityPropsWithHandler<TContext>;
 
 interface IReplacementEffectAbilityWhenProps<TSource extends Card> extends IReplacementEffectAbilityBaseProps<TSource> {
     when: WhenType<TSource>;

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -8,7 +8,6 @@ import type { GameEvent } from './core/event/GameEvent';
 import type { IActionTargetResolver, IActionTargetsResolver, ITriggeredAbilityTargetResolver, ITriggeredAbilityTargetsResolver } from './TargetInterfaces';
 import { IReplacementEffectSystemProperties } from './gameSystems/ReplacementEffectSystem';
 import { IInitiateAttackProperties } from './gameSystems/InitiateAttackSystem';
-import { MetaSystem } from './core/gameSystem/MetaSystem';
 
 // allow block comments without spaces so we can have compact jsdoc descriptions in this file
 /* eslint @stylistic/js/lines-around-comment: off */
@@ -149,7 +148,7 @@ interface IAbilityPropsWithTargetResolvers<TContext extends AbilityContext> exte
 }
 
 interface IAbilityPropsWithImmediateEffect<TContext extends AbilityContext> extends IAbilityProps<TContext> {
-    immediateEffect: GameSystem | MetaSystem<TContext>;
+    immediateEffect: GameSystem<TContext>;
 }
 
 interface IAbilityPropsWithHandler<TContext extends AbilityContext> extends IAbilityProps<TContext> {

--- a/server/game/TargetInterfaces.ts
+++ b/server/game/TargetInterfaces.ts
@@ -4,7 +4,6 @@ import type { GameSystem } from './core/gameSystem/GameSystem';
 import type { Card } from './core/card/Card';
 import type CardAbility from './core/ability/CardAbility';
 import type { RelativePlayer, TargetMode, CardType, Location, EventName, PhaseName, LocationFilter, WildcardCardType, CardTypeFilter } from './core/Constants';
-import { MetaSystem } from './core/gameSystem/MetaSystem';
 
 // allow block comments without spaces so we can have compact jsdoc descriptions in this file
 /* eslint @stylistic/js/lines-around-comment: off */
@@ -21,7 +20,7 @@ export type IActionTargetResolver<TContext extends AbilityContext = AbilityConte
 export type IActionTargetsResolver<TContext extends AbilityContext = AbilityContext> = Record<string, IActionTargetResolver<TContext>>;
 
 // ********************************************** INTERNAL TYPES **********************************************
-type IChoicesInterface<TContext extends AbilityContext = AbilityContext> = Record<string, ((context: TContext) => boolean) | GameSystem | MetaSystem<TContext>>;
+type IChoicesInterface<TContext extends AbilityContext = AbilityContext> = Record<string, ((context: TContext) => boolean) | GameSystem<TContext>>;
 
 interface ITargetResolverBase<TContext extends AbilityContext> {
     activePromptTitle?: string;
@@ -31,7 +30,7 @@ interface ITargetResolverBase<TContext extends AbilityContext> {
     /** Selects which player is choosing the target (defaults to the player controlling the source card) */
     choosingPlayer?: ((context: TContext) => RelativePlayer) | RelativePlayer;
     hideIfNoLegalTargets?: boolean;
-    immediateEffect?: GameSystem | MetaSystem<TContext>;
+    immediateEffect?: GameSystem<TContext>;
     dependsOn?: string;
 }
 

--- a/server/game/TargetInterfaces.ts
+++ b/server/game/TargetInterfaces.ts
@@ -4,89 +4,90 @@ import type { GameSystem } from './core/gameSystem/GameSystem';
 import type { Card } from './core/card/Card';
 import type CardAbility from './core/ability/CardAbility';
 import type { RelativePlayer, TargetMode, CardType, Location, EventName, PhaseName, LocationFilter, WildcardCardType, CardTypeFilter } from './core/Constants';
+import { MetaSystem } from './core/gameSystem/MetaSystem';
 
 // allow block comments without spaces so we can have compact jsdoc descriptions in this file
 /* eslint @stylistic/js/lines-around-comment: off */
 
 // ********************************************** EXPORTED TYPES **********************************************
-export type ITriggeredAbilityTargetResolver =
-    | (ICardTargetResolver & ITriggeredAbilityCardTargetResolver)
-    | ISelectTargetResolver;
+export type ITriggeredAbilityTargetResolver<TContext extends TriggeredAbilityContext = TriggeredAbilityContext> =
+    | (ICardTargetResolver<TContext> & ITriggeredAbilityCardTargetResolver<TContext>)
+    | ISelectTargetResolver<TContext>;
 
-export type ITriggeredAbilityTargetsResolver = Record<string, ITriggeredAbilityTargetResolver & ITriggeredAbilityTargetResolver>;
+export type ITriggeredAbilityTargetsResolver<TContext extends TriggeredAbilityContext = TriggeredAbilityContext> = Record<string, ITriggeredAbilityTargetResolver<TContext> & ITriggeredAbilityTargetResolver<TContext>>;
 
-export type IActionTargetResolver = (ICardTargetResolver & IActionCardTargetResolver) | ISelectTargetResolver | IAbilityTargetResolver;
+export type IActionTargetResolver<TContext extends AbilityContext = AbilityContext> = (ICardTargetResolver<TContext> & IActionCardTargetResolver<TContext>) | ISelectTargetResolver<TContext> | IAbilityTargetResolver<TContext>;
 
-export type IActionTargetsResolver = Record<string, IActionTargetResolver>;
+export type IActionTargetsResolver<TContext extends AbilityContext = AbilityContext> = Record<string, IActionTargetResolver<TContext>>;
 
 // ********************************************** INTERNAL TYPES **********************************************
-type IChoicesInterface = Record<string, ((context: AbilityContext) => boolean) | GameSystem>;
+type IChoicesInterface<TContext extends AbilityContext = AbilityContext> = Record<string, ((context: TContext) => boolean) | GameSystem | MetaSystem<TContext>>;
 
-interface ITargetResolverBase {
+interface ITargetResolverBase<TContext extends AbilityContext> {
     activePromptTitle?: string;
     locationFilter?: LocationFilter | LocationFilter[];
     /** Filter cards by their controller */
-    controller?: ((context: AbilityContext) => RelativePlayer) | RelativePlayer;
+    controller?: ((context: TContext) => RelativePlayer) | RelativePlayer;
     /** Selects which player is choosing the target (defaults to the player controlling the source card) */
-    choosingPlayer?: ((context: AbilityContext) => RelativePlayer) | RelativePlayer;
+    choosingPlayer?: ((context: TContext) => RelativePlayer) | RelativePlayer;
     hideIfNoLegalTargets?: boolean;
-    immediateEffect?: GameSystem;
+    immediateEffect?: GameSystem | MetaSystem<TContext>;
     dependsOn?: string;
 }
 
-interface ISelectTargetResolver extends ITargetResolverBase {
+interface ISelectTargetResolver<TContext extends AbilityContext> extends ITargetResolverBase<TContext> {
     mode: TargetMode.Select;
-    choices: (IChoicesInterface | object) | ((context: AbilityContext) => IChoicesInterface | object);
-    condition?: (context: AbilityContext) => boolean;
+    choices: (IChoicesInterface | object) | ((context: TContext) => IChoicesInterface | object);
+    condition?: (context: TContext) => boolean;
     checkTarget?: boolean;
 }
 
-interface IAbilityTargetResolver extends ITargetResolverBase {
+interface IAbilityTargetResolver<TContext extends AbilityContext> extends ITargetResolverBase<TContext> {
     mode: TargetMode.Ability;
     cardTypeFilter?: CardTypeFilter | CardTypeFilter[];
-    cardCondition?: (card: Card, context?: AbilityContext) => boolean;
+    cardCondition?: (card: Card, context?: TContext) => boolean;
     abilityCondition?: (ability: CardAbility) => boolean;
 }
 
-interface ICardTargetResolverBase extends ITargetResolverBase {
+interface ICardTargetResolverBase<TContext extends AbilityContext> extends ITargetResolverBase<TContext> {
     cardTypeFilter?: CardTypeFilter | CardTypeFilter[];
     locationFilter?: LocationFilter | LocationFilter[];
     optional?: boolean;
 }
 
-interface ICardExactlyUpToTargetResolver extends ICardTargetResolverBase {
+interface ICardExactlyUpToTargetResolver<TContext extends AbilityContext> extends ICardTargetResolverBase<TContext> {
     mode: TargetMode.Exactly | TargetMode.UpTo;
     numCards: number;
     sameDiscardPile?: boolean;
 }
 
-interface ICardExactlyUpToVariableTargetResolver extends ICardTargetResolverBase {
+interface ICardExactlyUpToVariableTargetResolver<TContext extends AbilityContext> extends ICardTargetResolverBase<TContext> {
     mode: TargetMode.ExactlyVariable | TargetMode.UpToVariable;
-    numCardsFunc: (context: AbilityContext) => number;
+    numCardsFunc: (context: TContext) => number;
 }
 
-interface ICardMaxStatTargetResolver extends ICardTargetResolverBase {
+interface ICardMaxStatTargetResolver<TContext extends AbilityContext> extends ICardTargetResolverBase<TContext> {
     mode: TargetMode.MaxStat;
     numCards: number;
     cardStat: (card: Card) => number;
     maxStat: () => number;
 }
 
-interface CardSingleUnlimitedTargetResolver extends ICardTargetResolverBase {
+interface CardSingleUnlimitedTargetResolver<TContext extends AbilityContext> extends ICardTargetResolverBase<TContext> {
     mode?: TargetMode.Single | TargetMode.Unlimited;
 }
 
-type ICardTargetResolver =
-    | ICardExactlyUpToTargetResolver
-    | ICardExactlyUpToVariableTargetResolver
-    | ICardMaxStatTargetResolver
-    | CardSingleUnlimitedTargetResolver
-    | IAbilityTargetResolver;
+type ICardTargetResolver<TContext extends AbilityContext> =
+    | ICardExactlyUpToTargetResolver<TContext>
+    | ICardExactlyUpToVariableTargetResolver<TContext>
+    | ICardMaxStatTargetResolver<TContext>
+    | CardSingleUnlimitedTargetResolver<TContext>
+    | IAbilityTargetResolver<TContext>;
 
-interface IActionCardTargetResolver {
-    cardCondition?: (card: Card, context?: AbilityContext) => boolean;
+interface IActionCardTargetResolver<TContext extends AbilityContext> {
+    cardCondition?: (card: Card, context?: TContext) => boolean;
 }
 
-interface ITriggeredAbilityCardTargetResolver {
-    cardCondition?: (card: Card, context?: TriggeredAbilityContext) => boolean;
+interface ITriggeredAbilityCardTargetResolver<TContext extends AbilityContext> {
+    cardCondition?: (card: Card, context?: TContext) => boolean;
 }

--- a/server/game/abilities/keyword/AmbushAbility.ts
+++ b/server/game/abilities/keyword/AmbushAbility.ts
@@ -3,7 +3,7 @@ import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import { Card } from '../../core/card/Card';
 import { KeywordName } from '../../core/Constants';
 import Game from '../../core/Game';
-import Contract from '../../core/utils/Contract';
+import * as Contract from '../../core/utils/Contract';
 import { ITriggeredAbilityProps } from '../../Interfaces';
 
 /** @deprecated this is still WIP until attack changes are done */

--- a/server/game/abilities/keyword/RestoreAbility.ts
+++ b/server/game/abilities/keyword/RestoreAbility.ts
@@ -2,7 +2,7 @@ import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import { Card } from '../../core/card/Card';
 import { CardType, KeywordName, RelativePlayer, WildcardLocation } from '../../core/Constants';
 import Game from '../../core/Game';
-import Contract from '../../core/utils/Contract';
+import * as Contract from '../../core/utils/Contract';
 import * as GameSystemLibrary from '../../gameSystems/GameSystemLibrary';
 import { ITriggeredAbilityProps } from '../../Interfaces';
 
@@ -23,9 +23,8 @@ export class RestoreAbility extends TriggeredAbility {
     }
 
     public constructor(game: Game, card: Card, restoreAmount: number) {
-        if (!Contract.assertTrue(card.isUnit()) || !Contract.assertNonNegative(restoreAmount)) {
-            return;
-        }
+        Contract.assertTrue(card.isUnit());
+        Contract.assertNonNegative(restoreAmount);
 
         const properties = RestoreAbility.buildRestoreAbilityProperties(restoreAmount);
 

--- a/server/game/abilities/keyword/RestoreAbility.ts
+++ b/server/game/abilities/keyword/RestoreAbility.ts
@@ -9,7 +9,7 @@ import { ITriggeredAbilityProps } from '../../Interfaces';
 export class RestoreAbility extends TriggeredAbility {
     public override readonly keyword: KeywordName | null = KeywordName.Restore;
 
-    public static buildRestoreAbilityProperties(restoreAmount: number): ITriggeredAbilityProps {
+    public static buildRestoreAbilityProperties<TSource extends Card = Card>(restoreAmount: number): ITriggeredAbilityProps<TSource> {
         return {
             title: `Restore ${restoreAmount}`,
             when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },

--- a/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
+++ b/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
@@ -4,7 +4,7 @@ import { TriggeredAbilityContext } from '../../core/ability/TriggeredAbilityCont
 import { Card } from '../../core/card/Card';
 import { KeywordName } from '../../core/Constants';
 import Game from '../../core/Game';
-import Contract from '../../core/utils/Contract';
+import * as Contract from '../../core/utils/Contract';
 import { ITriggeredAbilityProps } from '../../Interfaces';
 
 export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
@@ -31,9 +31,7 @@ export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
     }
 
     public constructor(game: Game, card: Card) {
-        if (!Contract.assertTrue(card.isUnit())) {
-            return;
-        }
+        Contract.assertTrue(card.isUnit());
 
         const properties = SaboteurDefeatShieldsAbility.buildSaboteurAbilityProperties();
 

--- a/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
+++ b/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
@@ -1,7 +1,9 @@
 import AbilityHelper from '../../AbilityHelper';
+import Shield from '../../cards/01_SOR/tokens/Shield';
 import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import { TriggeredAbilityContext } from '../../core/ability/TriggeredAbilityContext';
 import { Card } from '../../core/card/Card';
+import { UnitCard } from '../../core/card/CardTypes';
 import { KeywordName } from '../../core/Constants';
 import Game from '../../core/Game';
 import * as Contract from '../../core/utils/Contract';
@@ -23,9 +25,16 @@ export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
 
                     return card === attacker.activeAttack.target && card.hasShield();
                 },
-                immediateEffect: AbilityHelper.immediateEffects.defeat((context) => ({
-                    target: context.source.activeAttack.target.upgrades?.filter((card) => card.isShield())
-                }))
+                immediateEffect: AbilityHelper.immediateEffects.defeat((context: TriggeredAbilityContext<UnitCard>) => {
+                    let target: Shield[];
+                    if (context.source.activeAttack?.target.isUnit()) {
+                        target = context.source.activeAttack.target.upgrades?.filter((card) => card.isShield());
+                    } else {
+                        target = [];
+                    }
+
+                    return { target };
+                })
             }
         };
     }

--- a/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
+++ b/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
@@ -12,7 +12,7 @@ import { ITriggeredAbilityProps } from '../../Interfaces';
 export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
     public override readonly keyword: KeywordName | null = KeywordName.Saboteur;
 
-    public static buildSaboteurAbilityProperties(): ITriggeredAbilityProps {
+    public static buildSaboteurAbilityProperties<TSource extends Card = Card>(): ITriggeredAbilityProps<TSource> {
         return {
             title: 'Saboteur: defeat all shields',
             when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
@@ -25,7 +25,9 @@ export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
 
                     return card === attacker.activeAttack.target && card.hasShield();
                 },
-                immediateEffect: AbilityHelper.immediateEffects.defeat((context: TriggeredAbilityContext<UnitCard>) => {
+                immediateEffect: AbilityHelper.immediateEffects.defeat((context) => {
+                    Contract.assertTrue(context.source.isUnit());
+
                     let target: Shield[];
                     if (context.source.activeAttack?.target.isUnit()) {
                         target = context.source.activeAttack.target.upgrades?.filter((card) => card.isShield());

--- a/server/game/abilities/keyword/ShieldedAbility.ts
+++ b/server/game/abilities/keyword/ShieldedAbility.ts
@@ -1,4 +1,5 @@
 import AbilityHelper from '../../AbilityHelper';
+import { AbilityContext } from '../../core/ability/AbilityContext';
 import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import { Card } from '../../core/card/Card';
 import { KeywordName } from '../../core/Constants';
@@ -9,7 +10,7 @@ import { ITriggeredAbilityProps } from '../../Interfaces';
 export class ShieldedAbility extends TriggeredAbility {
     public override readonly keyword: KeywordName | null = KeywordName.Shielded;
 
-    public static buildShieldedAbilityProperties(): ITriggeredAbilityProps {
+    public static buildShieldedAbilityProperties<TSource extends Card = Card>(): ITriggeredAbilityProps<TSource> {
         return {
             title: 'Shielded',
             when: { onUnitEntersPlay: (event, context) => event.card === context.source },

--- a/server/game/abilities/keyword/ShieldedAbility.ts
+++ b/server/game/abilities/keyword/ShieldedAbility.ts
@@ -3,7 +3,7 @@ import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import { Card } from '../../core/card/Card';
 import { KeywordName } from '../../core/Constants';
 import Game from '../../core/Game';
-import Contract from '../../core/utils/Contract';
+import * as Contract from '../../core/utils/Contract';
 import { ITriggeredAbilityProps } from '../../Interfaces';
 
 export class ShieldedAbility extends TriggeredAbility {
@@ -18,9 +18,7 @@ export class ShieldedAbility extends TriggeredAbility {
     }
 
     public constructor(game: Game, card: Card) {
-        if (!Contract.assertTrue(card.isUnit())) {
-            return;
-        }
+        Contract.assertTrue(card.isUnit());
 
         const properties = ShieldedAbility.buildShieldedAbilityProperties();
 

--- a/server/game/actions/PlayEventAction.ts
+++ b/server/game/actions/PlayEventAction.ts
@@ -19,7 +19,7 @@ export class PlayEventAction extends PlayCardAction {
             context.player,
             context.source,
         );
-        context.game.resolveAbility((context.source as EventCard).getEventAbility().createContext());
+        context.game.resolveAbility(context.source.getEventAbility().createContext());
     }
 
     public override meetsRequirements(context = this.createContext(), ignoredRequirements: string[] = []): string {

--- a/server/game/actions/PlayEventAction.ts
+++ b/server/game/actions/PlayEventAction.ts
@@ -11,7 +11,6 @@ export class PlayEventAction extends PlayCardAction {
     }
 
     public override executeHandler(context: PlayCardContext): void {
-        // TODO THIS PR: try forcing context.source to be Card
         Contract.assertTrue(context.source.isEvent());
 
         context.game.addMessage(

--- a/server/game/actions/PlayEventAction.ts
+++ b/server/game/actions/PlayEventAction.ts
@@ -1,7 +1,7 @@
 import type { AbilityContext } from '../core/ability/AbilityContext.js';
 import { AbilityRestriction } from '../core/Constants.js';
 import { Card } from '../core/card/Card';
-import Contract from '../core/utils/Contract.js';
+import * as Contract from '../core/utils/Contract.js';
 import { EventCard } from '../core/card/EventCard.js';
 import { PlayCardContext, PlayCardAction } from '../core/ability/PlayCardAction.js';
 
@@ -11,9 +11,8 @@ export class PlayEventAction extends PlayCardAction {
     }
 
     public override executeHandler(context: PlayCardContext): void {
-        if (!Contract.assertTrue(context.source.isEvent())) {
-            return;
-        }
+        // TODO THIS PR: try forcing context.source to be Card
+        Contract.assertTrue(context.source.isEvent());
 
         context.game.addMessage(
             '{0} plays {1}',

--- a/server/game/actions/PlayUnitAction.ts
+++ b/server/game/actions/PlayUnitAction.ts
@@ -4,6 +4,7 @@ import { putIntoPlay } from '../gameSystems/GameSystemLibrary.js';
 import { Card } from '../core/card/Card';
 import { GameEvent } from '../core/event/GameEvent.js';
 import { PlayCardContext, PlayCardAction } from '../core/ability/PlayCardAction.js';
+import * as Contract from '../core/utils/Contract.js';
 
 export class PlayUnitAction extends PlayCardAction {
     public constructor(card: Card) {
@@ -11,6 +12,8 @@ export class PlayUnitAction extends PlayCardAction {
     }
 
     public override executeHandler(context: PlayCardContext): void {
+        Contract.assertTrue(context.source.isUnit());
+
         const cardPlayedEvent = new GameEvent(EventName.OnCardPlayed, {
             player: context.player,
             card: context.source,

--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -1,8 +1,10 @@
 import { AbilityContext } from '../core/ability/AbilityContext';
 import { PlayCardContext, PlayCardAction } from '../core/ability/PlayCardAction';
 import { Card } from '../core/card/Card';
+import { UpgradeCard } from '../core/card/UpgradeCard';
 import { AbilityRestriction, EventName, Location, PhaseName, PlayType, RelativePlayer } from '../core/Constants';
 import { GameEvent } from '../core/event/GameEvent';
+import * as Contract from '../core/utils/Contract';
 import { payPlayCardResourceCost } from '../costs/CostLibrary';
 import { attachUpgrade } from '../gameSystems/GameSystemLibrary';
 
@@ -10,11 +12,13 @@ export class PlayUpgradeAction extends PlayCardAction {
     // we pass in a targetResolver holding the attachUpgrade system so that the action will be blocked if there are no valid targets
     public constructor(card: Card) {
         super(card, 'Play this upgrade', [], { immediateEffect: attachUpgrade((context) => ({
-            upgrade: context.source
+            upgrade: (context.source as UpgradeCard)
         })) });
     }
 
     public override executeHandler(context: PlayCardContext) {
+        Contract.assertTrue(context.source.isUpgrade());
+
         const cardPlayedEvent = new GameEvent(EventName.OnCardPlayed, {
             player: context.player,
             card: context.source,

--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -11,8 +11,8 @@ import { attachUpgrade } from '../gameSystems/GameSystemLibrary';
 export class PlayUpgradeAction extends PlayCardAction {
     // we pass in a targetResolver holding the attachUpgrade system so that the action will be blocked if there are no valid targets
     public constructor(card: Card) {
-        super(card, 'Play this upgrade', [], { immediateEffect: attachUpgrade((context) => ({
-            upgrade: (context.source as UpgradeCard)
+        super(card, 'Play this upgrade', [], { immediateEffect: attachUpgrade<AbilityContext<UpgradeCard>>((context) => ({
+            upgrade: context.source
         })) });
     }
 

--- a/server/game/cards/01_SOR/events/MedalCeremony.ts
+++ b/server/game/cards/01_SOR/events/MedalCeremony.ts
@@ -30,7 +30,7 @@ export default class MedalCeremony extends EventCard {
                 cardCondition: (card, context) => {
                     const rebelUnitsAttackedThisPhase =
                         this.attacksThisPhaseWatcher.getAttackers((attack) => attack.attacker.hasSomeTrait(Trait.Rebel));
-                    return rebelUnitsAttackedThisPhase.includes(card as UnitCard);
+                    return rebelUnitsAttackedThisPhase.includes(card);
                 }
             }
         });

--- a/server/game/cards/01_SOR/tokens/Shield.ts
+++ b/server/game/cards/01_SOR/tokens/Shield.ts
@@ -2,7 +2,7 @@ import AbilityHelper from '../../../AbilityHelper';
 import { TokenUpgradeCard } from '../../../core/card/TokenCards';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import Player from '../../../core/Player';
-import Contract from '../../../core/utils/Contract';
+import * as Contract from '../../../core/utils/Contract';
 
 export default class Shield extends TokenUpgradeCard {
     protected override getImplementationId() {

--- a/server/game/cards/01_SOR/tokens/Shield.ts
+++ b/server/game/cards/01_SOR/tokens/Shield.ts
@@ -35,14 +35,14 @@ export default class Shield extends TokenUpgradeCard {
         this.addReplacementEffectAbility({
             title: 'Defeat shield to prevent attached unit from taking damage',
             when: {
-                onDamageDealt: (event, context) => event.card === (context.source as UpgradeCard).parentCard
+                onDamageDealt: (event, context) => event.card === context.source.parentCard
             },
             replaceWith: {
                 target: this,
                 replacementImmediateEffect: AbilityHelper.immediateEffects.defeat()
             },
             effect: 'shield prevents {1} from taking damage',
-            effectArgs: (context) => [(context.source as UpgradeCard).parentCard],
+            effectArgs: (context) => [context.source.parentCard],
         });
     }
 }

--- a/server/game/cards/01_SOR/upgrades/LukesLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/LukesLightsaber.ts
@@ -1,5 +1,4 @@
 import AbilityHelper from '../../../AbilityHelper';
-import { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
 import { Card } from '../../../core/card/Card';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
@@ -24,7 +23,7 @@ export default class LukesLightsaber extends UpgradeCard {
     public override setupCardAbilities() {
         this.addWhenPlayedAbility({
             title: 'Heal all damage from Luke and give him a shield token',
-            immediateEffect: AbilityHelper.immediateEffects.conditional((context: TriggeredAbilityContext<this>) => ({
+            immediateEffect: AbilityHelper.immediateEffects.conditional((context) => ({
                 target: context.source.parentCard,
                 condition: context.source.parentCard?.title === 'Luke Skywalker',
                 onTrue: AbilityHelper.immediateEffects.simultaneous([

--- a/server/game/cards/01_SOR/upgrades/LukesLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/LukesLightsaber.ts
@@ -1,4 +1,5 @@
 import AbilityHelper from '../../../AbilityHelper';
+import { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
 import { Card } from '../../../core/card/Card';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
@@ -23,7 +24,7 @@ export default class LukesLightsaber extends UpgradeCard {
     public override setupCardAbilities() {
         this.addWhenPlayedAbility({
             title: 'Heal all damage from Luke and give him a shield token',
-            immediateEffect: AbilityHelper.immediateEffects.conditional((context) => ({
+            immediateEffect: AbilityHelper.immediateEffects.conditional((context: TriggeredAbilityContext<this>) => ({
                 target: context.source.parentCard,
                 condition: context.source.parentCard?.title === 'Luke Skywalker',
                 onTrue: AbilityHelper.immediateEffects.simultaneous([

--- a/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
@@ -5,6 +5,7 @@ import { Card } from '../../../core/card/Card';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { CardType, KeywordName, Location, Trait, WildcardCardType } from '../../../core/Constants';
 import Player from '../../../core/Player';
+import { ITriggeredAbilityBaseProps } from '../../../Interfaces';
 
 export default class VadersLightsaber extends UpgradeCard {
     protected override getImplementationId() {
@@ -30,7 +31,7 @@ export default class VadersLightsaber extends UpgradeCard {
                 locationFilter: Location.GroundArena,
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context: TriggeredAbilityContext<this>) => context.source.parentCard?.title === 'Darth Vader',      // TODO THIS PR: can we make this cast go away?
+                    condition: (context) => context.source.parentCard?.title === 'Darth Vader',
                     onTrue: AbilityHelper.immediateEffects.damage({ amount: 4 }),
                     onFalse: AbilityHelper.immediateEffects.noAction()
                 })

--- a/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
@@ -1,11 +1,8 @@
 import AbilityHelper from '../../../AbilityHelper';
-import { AbilityContext } from '../../../core/ability/AbilityContext';
-import { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
 import { Card } from '../../../core/card/Card';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { CardType, KeywordName, Location, Trait, WildcardCardType } from '../../../core/Constants';
 import Player from '../../../core/Player';
-import { ITriggeredAbilityBaseProps } from '../../../Interfaces';
 
 export default class VadersLightsaber extends UpgradeCard {
     protected override getImplementationId() {

--- a/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
@@ -1,4 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
+import { AbilityContext } from '../../../core/ability/AbilityContext';
+import { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
 import { Card } from '../../../core/card/Card';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { CardType, KeywordName, Location, Trait, WildcardCardType } from '../../../core/Constants';
@@ -28,7 +30,7 @@ export default class VadersLightsaber extends UpgradeCard {
                 locationFilter: Location.GroundArena,
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => context.source.parentCard?.title === 'Darth Vader',
+                    condition: (context: TriggeredAbilityContext<this>) => context.source.parentCard?.title === 'Darth Vader',      // TODO THIS PR: can we make this cast go away?
                     onTrue: AbilityHelper.immediateEffects.damage({ amount: 4 }),
                     onFalse: AbilityHelper.immediateEffects.noAction()
                 })

--- a/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
+++ b/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
@@ -26,7 +26,7 @@ export default class VambraceGrappleshot extends UpgradeCard {
             title: 'Exhaust the defender on attack',
             when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
             immediateEffect: AbilityHelper.immediateEffects.exhaust((context) => {
-                return { target: (context as TriggeredAbilityContext)?.event.attack.target };
+                return { target: context.source.isUnit() ? context.source.activeAttack?.target : null };
             })
         });
     }

--- a/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
+++ b/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
@@ -26,7 +26,7 @@ export default class VambraceGrappleshot extends UpgradeCard {
             title: 'Exhaust the defender on attack',
             when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
             immediateEffect: AbilityHelper.immediateEffects.exhaust((context) => {
-                return { target: context.source.isUnit() ? context.source.activeAttack?.target : null };
+                return { target: context.source.activeAttack?.target };
             })
         });
     }

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -156,14 +156,10 @@ class Game extends EventEmitter {
      * @returns {Player}
      */
     getPlayerByName(playerName) {
-        if (!Contract.assertHasProperty(this.playersAndSpectators, playerName)) {
-            return null;
-        }
+        Contract.assertHasProperty(this.playersAndSpectators, playerName);
 
         let player = this.playersAndSpectators[playerName];
-        if (!Contract.assertFalse(this.isSpectator(player), `Player ${playerName} is a spectator`)) {
-            return null;
-        }
+        Contract.assertFalse(this.isSpectator(player), `Player ${playerName} is a spectator`);
 
         return player;
     }
@@ -587,9 +583,7 @@ class Game extends EventEmitter {
      * @param {Object} properties - see menuprompt.js
      */
     promptWithMenu(player, contextObj, properties) {
-        if (!Contract.assertNotNullLike(player)) {
-            return;
-        }
+        Contract.assertNotNullLike(player);
 
         this.queueStep(new MenuPrompt(this, player, contextObj, properties));
     }
@@ -600,9 +594,7 @@ class Game extends EventEmitter {
      * @param {Object} properties - see handlermenuprompt.js
      */
     promptWithHandlerMenu(player, properties) {
-        if (!Contract.assertNotNullLike(player)) {
-            return;
-        }
+        Contract.assertNotNullLike(player);
 
         this.queueStep(new HandlerMenuPrompt(this, player, properties));
     }
@@ -613,9 +605,7 @@ class Game extends EventEmitter {
      * @param {Object} properties - see selectcardprompt.js
      */
     promptForSelect(player, properties) {
-        if (!Contract.assertNotNullLike(player)) {
-            return;
-        }
+        Contract.assertNotNullLike(player);
 
         this.queueStep(new SelectCardPrompt(this, player, properties));
     }
@@ -1145,13 +1135,9 @@ class Game extends EventEmitter {
      * @param {import('./card/CardTypes.js').TokenCard} token
      */
     removeTokenFromPlay(token) {
-        if (
-            !Contract.assertEqual(token.location, Location.OutsideTheGame,
-                `Tokens must be moved to location ${Location.OutsideTheGame} before removing from play, instead found token at ${token.location}`
-            )
-        ) {
-            return;
-        }
+        Contract.assertEqual(token.location, Location.OutsideTheGame,
+            `Tokens must be moved to location ${Location.OutsideTheGame} before removing from play, instead found token at ${token.location}`
+        );
 
         const player = token.owner;
         this.filterCardFromList(token, this.allCards);

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -250,9 +250,7 @@ class Player extends GameObject {
      * @param {Function} predicate - BaseCard => Boolean
      */
     findCards(cardList, predicate) {
-        if (!Contract.assertNotNullLike(cardList)) {
-            return null;
-        }
+        Contract.assertNotNullLike(cardList);
 
         var cardsToReturn = [];
 
@@ -529,9 +527,7 @@ class Player extends GameObject {
     }
 
     addPlayableLocation(type, player, location, cards = []) {
-        if (!Contract.assertNotNullLike(player)) {
-            return null;
-        }
+        Contract.assertNotNullLike(player);
         let playableLocation = new PlayableLocation(type, player, location, new Set(cards));
         this.playableLocations.push(playableLocation);
         return playableLocation;
@@ -915,13 +911,9 @@ class Player extends GameObject {
 
         var targetPile = this.getCardPile(targetLocation);
 
-        if (!Contract.assertTrue(this.isLegalLocationForCardType(card.type, targetLocation), `Tried to move card ${card.name} to ${targetLocation} but it is not a legal location`)) {
-            return;
-        }
+        Contract.assertTrue(this.isLegalLocationForCardType(card.type, targetLocation), `Tried to move card ${card.name} to ${targetLocation} but it is not a legal location`);
 
-        if (!Contract.assertFalse(targetPile.includes(card), `Tried to move card ${card.name} to ${targetLocation} but it is already there`)) {
-            return;
-        }
+        Contract.assertFalse(targetPile.includes(card), `Tried to move card ${card.name} to ${targetLocation} but it is already there`);
 
         let currentLocation = card.location;
 
@@ -1026,18 +1018,12 @@ class Player extends GameObject {
      * Other card types (or other types of upgrade move) must use {@link Player.moveCard}.
      */
     putUpgradeInArena(upgrade, location) {
-        if (
-            !Contract.assertTrue(upgrade.isUpgrade()) ||
-            !Contract.assertTrue(EnumHelpers.isArena(location))
-        ) {
-            return;
-        }
+        Contract.assertTrue(upgrade.isUpgrade());
+        Contract.assertTrue(EnumHelpers.isArena(location));
 
         const pile = this.getCardPile(location);
 
-        if (!Contract.assertFalse(pile.includes(upgrade), `Tried to move upgrade ${upgrade.name} to ${location} for ${this.name} but it is already there`)) {
-            return;
-        }
+        Contract.assertFalse(pile.includes(upgrade), `Tried to move upgrade ${upgrade.name} to ${location} for ${this.name} but it is already there`);
 
         pile.push(upgrade);
     }

--- a/server/game/core/ability/AbilityContext.ts
+++ b/server/game/core/ability/AbilityContext.ts
@@ -4,6 +4,7 @@ import OngoingEffectSource from '../ongoingEffect/OngoingEffectSource';
 import type Game from '../Game';
 import type { GameSystem } from '../gameSystem/GameSystem';
 import type Player from '../Player';
+import { Card } from '../card/Card';
 
 export interface IAbilityContextProperties {
     game: Game;
@@ -25,7 +26,7 @@ export interface IAbilityContextProperties {
  * While the structure will vary from inheriting classes, it is guaranteed to have at least the `game` object, the
  * `player` that is executing the action, and the `source` card object that the ability is generated from.
  */
-export class AbilityContext<TSource = any> {
+export class AbilityContext<TSource extends Card = Card> {
     public game: Game;
     public source: TSource;
     public player: Player;
@@ -60,7 +61,7 @@ export class AbilityContext<TSource = any> {
         this.playType = this.player && this.player.findPlayType(this.source); //location && location.playingType;
     }
 
-    public copy(newProps: Partial<IAbilityContextProperties>): AbilityContext<this> {
+    public copy(newProps: Partial<IAbilityContextProperties>): AbilityContext<TSource> {
         const copy = this.createCopy(newProps);
         copy.target = this.target;
         copy.costAspects = this.costAspects;
@@ -72,8 +73,8 @@ export class AbilityContext<TSource = any> {
         return copy;
     }
 
-    public createCopy(newProps: Partial<IAbilityContextProperties>): AbilityContext<this> {
-        return new AbilityContext(Object.assign(this.getProps(), newProps));
+    public createCopy(newProps: Partial<IAbilityContextProperties>) {
+        return new AbilityContext<TSource>(Object.assign(this.getProps(), newProps));
     }
 
     public getProps(): IAbilityContextProperties {

--- a/server/game/core/ability/CardAbility.js
+++ b/server/game/core/ability/CardAbility.js
@@ -3,7 +3,7 @@ const CardAbilityStep = require('./CardAbilityStep.js');
 const Costs = require('../../costs/CostLibrary.js');
 const { Location, CardType, EffectName, WildcardLocation, AbilityType, PhaseName } = require('../Constants.js');
 const EnumHelpers = require('../utils/EnumHelpers.js');
-const { default: Contract } = require('../utils/Contract.js');
+const Contract = require('../utils/Contract.js');
 
 class CardAbility extends CardAbilityStep {
     constructor(game, card, properties, type = AbilityType.Action) {

--- a/server/game/core/ability/CardAbilityStep.js
+++ b/server/game/core/ability/CardAbilityStep.js
@@ -3,7 +3,7 @@ const PlayerOrCardAbility = require('./PlayerOrCardAbility.js');
 const { Stage, AbilityType } = require('../Constants.js');
 const AttackHelper = require('../attack/AttackHelper.js');
 const Helpers = require('../utils/Helpers.js');
-const { default: Contract } = require('../utils/Contract.js');
+const Contract = require('../utils/Contract.js');
 
 /**
  * Represents one step from a card's text ability. Checks are simpler than for a

--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -1,6 +1,6 @@
 import { IKeywordProperties } from '../../Interfaces';
 import { AbilityType, KeywordName } from '../Constants';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import { KeywordInstance, KeywordWithNumericValue } from './KeywordInstance';
 
@@ -84,11 +84,7 @@ function isKeywordEnabled(keyword: KeywordName, cardText: string, cardName: stri
  * @returns null if the keyword is not enabled, or the numeric value if enabled
  */
 function parseNumericKeywordValueIfEnabled(keyword: KeywordName, cardText: string, cardName: string): number | null {
-    if (!Contract.assertTrue(
-        [KeywordName.Raid, KeywordName.Restore].includes(keyword)
-    )) {
-        return null;
-    }
+    Contract.assertTrue([KeywordName.Raid, KeywordName.Restore].includes(keyword));
 
     const regex = getRegexForKeyword(keyword);
     const matchIter = cardText.matchAll(regex);

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -3,7 +3,7 @@ const CardTargetResolver = require('./abilityTargets/CardTargetResolver.js');
 const SelectTargetResolver = require('./abilityTargets/SelectTargetResolver.js');
 const { Stage, TargetMode, AbilityType } = require('../Constants.js');
 const { GameEvent } = require('../event/GameEvent.js');
-const { default: Contract } = require('../utils/Contract.js');
+const Contract = require('../utils/Contract.js');
 const { GameSystem } = require('../gameSystem/GameSystem.js');
 const { has } = require('underscore');
 

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -6,7 +6,7 @@ import { GameEvent } from '../event/GameEvent';
 import { Card } from '../card/Card';
 import Game from '../Game';
 import { TriggeredAbilityWindow } from '../gameSteps/abilityWindow/TriggeredAbilityWindow';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import type CardAbilityStep from './CardAbilityStep';
 import { CardWithTriggeredAbilities } from '../card/CardTypes';
 
@@ -71,9 +71,7 @@ export default class TriggeredAbility extends CardAbility {
     }
 
     public eventHandler(event, window) {
-        if (!Contract.assertNotNullLike(window)) {
-            return;
-        }
+        Contract.assertNotNullLike(window);
 
         // IMPORTANT: the below code is referenced in the debugging guide (docs/debugging-guide.md). If you make changes here, make sure to update that document as well.
         for (const player of this.game.getPlayers()) {

--- a/server/game/core/ability/TriggeredAbilityContext.ts
+++ b/server/game/core/ability/TriggeredAbilityContext.ts
@@ -5,7 +5,7 @@ interface ITriggeredAbilityContextProperties extends IAbilityContextProperties {
     event: any;
 }
 
-export class TriggeredAbilityContext<TSource = Card> extends AbilityContext<TSource> {
+export class TriggeredAbilityContext<TSource extends Card = Card> extends AbilityContext<TSource> {
     public event: any;
 
     public constructor(properties: ITriggeredAbilityContextProperties) {
@@ -14,7 +14,7 @@ export class TriggeredAbilityContext<TSource = Card> extends AbilityContext<TSou
     }
 
     public override createCopy(newProps: unknown) {
-        return new TriggeredAbilityContext<this>(Object.assign(this.getProps(), newProps));
+        return new TriggeredAbilityContext<TSource>(Object.assign(this.getProps(), newProps));
     }
 
     public override getProps() {

--- a/server/game/core/ability/abilityTargets/AbilityTargetResolver.js
+++ b/server/game/core/ability/abilityTargets/AbilityTargetResolver.js
@@ -1,7 +1,7 @@
 const CardSelector = require('../../cardSelector/CardSelector.js');
 const { Stage, RelativePlayer } = require('../../Constants.js');
 const { GameSystem } = require('../../gameSystem/GameSystem.js');
-const { default: Contract } = require('../../utils/Contract.js');
+const Contract = require('../../utils/Contract.js');
 const EnumHelpers = require('../../utils/EnumHelpers.js');
 
 /** Target resolver for effects that target abilities */
@@ -17,9 +17,7 @@ class AbilityTargetResolver {
             let dependsOnTarget = ability.targetResolvers.find((target) => target.name === this.properties.dependsOn);
 
             // assert that the target we depend on actually exists
-            if (!Contract.assertNotNullLike(dependsOnTarget)) {
-                return null;
-            }
+            Contract.assertNotNullLike(dependsOnTarget);
 
             dependsOnTarget.dependentTarget = this;
         }

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.js
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.js
@@ -1,7 +1,7 @@
 const Helpers = require('../../utils/Helpers.js');
 const CardSelector = require('../../cardSelector/CardSelector.js');
 const { Stage, RelativePlayer, EffectName, TargetMode } = require('../../Constants.js');
-const { default: Contract } = require('../../utils/Contract.js');
+const Contract = require('../../utils/Contract.js');
 const EnumHelpers = require('../../utils/EnumHelpers.js');
 const { GameSystem } = require('../../gameSystem/GameSystem.js');
 
@@ -24,9 +24,7 @@ class CardTargetResolver {
             let dependsOnTarget = ability.targetResolvers.find((target) => target.name === this.properties.dependsOn);
 
             // assert that the target we depend on actually exists
-            if (!Contract.assertNotNullLike(dependsOnTarget)) {
-                return null;
-            }
+            Contract.assertNotNullLike(dependsOnTarget);
 
             dependsOnTarget.dependentTarget = this;
         }

--- a/server/game/core/ability/abilityTargets/SelectTargetResolver.js
+++ b/server/game/core/ability/abilityTargets/SelectTargetResolver.js
@@ -1,6 +1,6 @@
 const { SelectChoice } = require('./SelectChoice.js');
 const { Stage, RelativePlayer } = require('../../Constants.js');
-const { default: Contract } = require('../../utils/Contract.js');
+const Contract = require('../../utils/Contract.js');
 const { GameSystem } = require('../../gameSystem/GameSystem.js');
 
 /** Target resolver for selecting between multiple prompted choices due to an effect */
@@ -14,9 +14,7 @@ class SelectTargetResolver {
             let dependsOnTarget = ability.targetResolvers.find((target) => target.name === this.properties.dependsOn);
 
             // assert that the target we depend on actually exists
-            if (!Contract.assertNotNullLike(dependsOnTarget)) {
-                return null;
-            }
+            Contract.assertNotNullLike(dependsOnTarget);
 
             dependsOnTarget.dependentTarget = this;
         }

--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -2,7 +2,7 @@ import { GameObject } from '../GameObject';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import type Game from '../Game';
 import type { Card } from '../card/Card';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { CardWithDamageProperty, UnitCard } from '../card/CardTypes';
 
 
@@ -55,9 +55,7 @@ export class Attack extends GameObject {
     }
 
     private getUnitPower(involvedUnit: UnitCard): StatisticTotal {
-        if (!Contract.assertTrue(EnumHelpers.isArena(involvedUnit.location), `Unit ${involvedUnit.name} location is ${involvedUnit.location}, cannot participate in combat`)) {
-            return null;
-        }
+        Contract.assertTrue(EnumHelpers.isArena(involvedUnit.location), `Unit ${involvedUnit.name} location is ${involvedUnit.location}, cannot participate in combat`);
 
         return involvedUnit.power;
     }

--- a/server/game/core/card/BaseCard.ts
+++ b/server/game/core/card/BaseCard.ts
@@ -1,7 +1,7 @@
 import Player from '../Player';
 import { Card } from './Card';
 import { CardType } from '../Constants';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { WithDamage } from './propertyMixins/Damage';
 import { ActionAbility } from '../ability/ActionAbility';
 import AbilityHelper from '../../AbilityHelper';
@@ -38,9 +38,7 @@ export class BaseCard extends BaseCardParent {
     }
 
     public setEpicActionAbility(properties: IEpicActionProps<this>): void {
-        if (!Contract.assertTrue(this._epicActionAbility == null, 'Epic action ability already set')) {
-            return;
-        }
+        Contract.assertTrue(this._epicActionAbility == null, 'Epic action ability already set');
 
         const propertiesWithLimit: IActionAbilityProps<this> = Object.assign(properties, {
             limit: AbilityHelper.limit.epicAction()

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -3,7 +3,7 @@ import { ActionAbility } from '../ability/ActionAbility';
 import PlayerOrCardAbility from '../ability/PlayerOrCardAbility';
 import OngoingEffectSource from '../ongoingEffect/OngoingEffectSource';
 import type Player from '../Player';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { AbilityRestriction, AbilityType, Arena, Aspect, CardType, EffectName, EventName, KeywordName, Location, Trait } from '../Constants';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import AbilityHelper from '../../AbilityHelper';

--- a/server/game/core/card/CardHelpers.ts
+++ b/server/game/core/card/CardHelpers.ts
@@ -1,6 +1,6 @@
 import { CardType } from '../Constants';
 import Player from '../Player';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { BaseCard } from './BaseCard';
 import { Card } from './Card';
 import { EventCard } from './EventCard';

--- a/server/game/core/card/EventCard.ts
+++ b/server/game/core/card/EventCard.ts
@@ -1,7 +1,7 @@
 import Player from '../Player';
 import { WithCost } from './propertyMixins/Cost';
 import { AbilityType, CardType, Location } from '../Constants';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { PlayableOrDeployableCard } from './baseClasses/PlayableOrDeployableCard';
 import { IEventAbilityProps } from '../../Interfaces';
 import { EventAbility } from '../ability/EventAbility';

--- a/server/game/core/card/LeaderCard.ts
+++ b/server/game/core/card/LeaderCard.ts
@@ -1,6 +1,6 @@
 import Player from '../Player';
 import { InPlayCard } from './baseClasses/InPlayCard';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { CardType } from '../Constants';
 
 export class LeaderCard extends InPlayCard {

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -9,7 +9,7 @@ import * as EnumHelpers from '../utils/EnumHelpers';
 import { IActionAbilityProps, IConstantAbilityProps, IReplacementEffectAbilityProps, ITriggeredAbilityProps } from '../../Interfaces';
 import * as Helpers from '../utils/Helpers';
 import AbilityHelper from '../../AbilityHelper';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 
 const LeaderUnitCardParent = WithUnitProperties(WithCost(LeaderCard));
 
@@ -47,9 +47,7 @@ export class LeaderUnitCard extends LeaderUnitCardParent {
 
     /** Deploy the leader to the arena. Handles the move operation and state changes. */
     public override deploy() {
-        if (!Contract.assertFalse(this._deployed, `Attempting to deploy already deployed leader ${this.internalName}`)) {
-            return;
-        }
+        Contract.assertFalse(this._deployed, `Attempting to deploy already deployed leader ${this.internalName}`);
 
         this._deployed = true;
         this.controller.moveCard(this, this.defaultArena);
@@ -57,9 +55,7 @@ export class LeaderUnitCard extends LeaderUnitCardParent {
 
     /** Return the leader from the arena to the base zone. Handles the move operation and state changes. */
     public undeploy() {
-        if (!Contract.assertTrue(this._deployed, `Attempting to un-deploy leader ${this.internalName} while it is not deployed`)) {
-            return;
-        }
+        Contract.assertTrue(this._deployed, `Attempting to un-deploy leader ${this.internalName} while it is not deployed`);
 
         this._deployed = false;
         this.controller.moveCard(this, Location.Base);

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -78,12 +78,12 @@ export class LeaderUnitCard extends LeaderUnitCardParent {
         super.addConstantAbility(properties);
     }
 
-    protected override addReplacementEffectAbility(properties: IReplacementEffectAbilityProps): void {
+    protected override addReplacementEffectAbility(properties: IReplacementEffectAbilityProps<this>): void {
         properties.locationFilter = this.getAbilityLocationsForSide(properties.locationFilter);
         super.addReplacementEffectAbility(properties);
     }
 
-    protected override addTriggeredAbility(properties: ITriggeredAbilityProps): void {
+    protected override addTriggeredAbility(properties: ITriggeredAbilityProps<this>): void {
         properties.locationFilter = this.getAbilityLocationsForSide(properties.locationFilter);
         super.addTriggeredAbility(properties);
     }

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -4,7 +4,7 @@ import { WithCost } from './propertyMixins/Cost';
 import { WithPrintedPower } from './propertyMixins/PrintedPower';
 import { InitiateAttackAction } from '../../actions/InitiateAttackAction';
 import { PlayUnitAction } from '../../actions/PlayUnitAction';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { CardType, Location } from '../Constants';
 import { WithDamage } from './propertyMixins/Damage';
 import { PlayableOrDeployableCard } from './baseClasses/PlayableOrDeployableCard';

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -108,7 +108,7 @@ export class UpgradeCard extends UpgradeCardParent {
      * Adds an "attached card gains [X]" ability, where X is a triggered ability. You can provide a match function
      * to narrow down whether the effect is applied (for cases where the effect has conditions).
      */
-    protected addGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityProps<this>, gainCondition: (context: AbilityContext<this>) => boolean = null) {
+    protected addGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityProps<UnitCard>, gainCondition: (context: AbilityContext<this>) => boolean = null) {
         this.addConstantAbilityTargetingAttached({
             title: 'Give ability to the attached card',
             condition: gainCondition,

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -3,7 +3,7 @@ import { WithPrintedHp } from './propertyMixins/PrintedHp';
 import { WithCost } from './propertyMixins/Cost';
 import { InPlayCard } from './baseClasses/InPlayCard';
 import { WithPrintedPower } from './propertyMixins/PrintedPower';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { AbilityType, CardType, KeywordName, Location, RelativePlayer } from '../Constants';
 import { UnitCard } from './CardTypes';
 import { PlayUpgradeAction } from '../../actions/PlayUpgradeAction';
@@ -33,31 +33,22 @@ export class UpgradeCard extends UpgradeCardParent {
     // TODO CAPTURE: we may need to use the "parent" concept for captured cards as well
     /** The card that this card is underneath */
     public get parentCard(): UnitCard {
-        if (!Contract.assertNotNullLike(this._parentCard) || !Contract.assertTrue(EnumHelpers.isArena(this.location))) {
-            return null;
-        }
+        Contract.assertNotNullLike(this._parentCard);
+        Contract.assertTrue(EnumHelpers.isArena(this.location));
 
         return this._parentCard;
     }
 
     public override moveTo(targetLocation: Location) {
-        if (
-            !Contract.assertFalse(this._parentCard && targetLocation !== this._parentCard.location,
-                `Attempting to move upgrade ${this.internalName} while it is still attached to ${this._parentCard?.internalName}`)
-        ) {
-            return;
-        }
+        Contract.assertFalse(this._parentCard && targetLocation !== this._parentCard.location,
+            `Attempting to move upgrade ${this.internalName} while it is still attached to ${this._parentCard?.internalName}`);
 
         super.moveTo(targetLocation);
     }
 
     public attachTo(newParentCard: UnitCard) {
-        if (
-            !Contract.assertTrue(newParentCard.isUnit()) ||
-            !Contract.assertTrue(EnumHelpers.isArena(newParentCard.location))
-        ) {
-            return;
-        }
+        Contract.assertTrue(newParentCard.isUnit());
+        Contract.assertTrue(EnumHelpers.isArena(newParentCard.location));
 
         if (this._parentCard) {
             this.unattach();
@@ -72,9 +63,7 @@ export class UpgradeCard extends UpgradeCardParent {
     }
 
     public unattach() {
-        if (!Contract.assertTrue(this._parentCard !== null, 'Attempting to unattach upgrade when already unattached')) {
-            return;
-        }
+        Contract.assertTrue(this._parentCard !== null, 'Attempting to unattach upgrade when already unattached');
 
         this.parentCard.unattachUpgrade(this);
         this.parentCard.controller.removeCardFromPile(this);

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -108,7 +108,7 @@ export class UpgradeCard extends UpgradeCardParent {
      * Adds an "attached card gains [X]" ability, where X is a triggered ability. You can provide a match function
      * to narrow down whether the effect is applied (for cases where the effect has conditions).
      */
-    protected addGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityProps, gainCondition: (context: AbilityContext) => boolean = null) {
+    protected addGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityProps<this>, gainCondition: (context: AbilityContext<this>) => boolean = null) {
         this.addConstantAbilityTargetingAttached({
             title: 'Give ability to the attached card',
             condition: gainCondition,
@@ -120,7 +120,7 @@ export class UpgradeCard extends UpgradeCardParent {
      * Adds an "attached card gains [X]" ability, where X is a keyword ability. You can provide a match function
      * to narrow down whether the effect is applied (for cases where the effect has conditions).
      */
-    protected addGainKeywordTargetingAttached(properties: IKeywordProperties, gainCondition: (context: AbilityContext) => boolean = null) {
+    protected addGainKeywordTargetingAttached(properties: IKeywordProperties, gainCondition: (context: AbilityContext<this>) => boolean = null) {
         this.addConstantAbilityTargetingAttached({
             title: 'Give keyword to the attached card',
             condition: gainCondition,

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -72,21 +72,21 @@ export class InPlayCard extends PlayableOrDeployableCard {
         this.constantAbilities.push(this.createConstantAbility(properties));
     }
 
-    protected addReplacementEffectAbility(properties: IReplacementEffectAbilityProps): void {
+    protected addReplacementEffectAbility(properties: IReplacementEffectAbilityProps<this>): void {
         // for initialization and tracking purposes, a ReplacementEffect is basically a Triggered ability
         this.triggeredAbilities.push(this.createReplacementEffectAbility(properties));
     }
 
-    protected addTriggeredAbility(properties: ITriggeredAbilityProps): void {
+    protected addTriggeredAbility(properties: ITriggeredAbilityProps<this>): void {
         this.triggeredAbilities.push(this.createTriggeredAbility(properties));
     }
 
-    protected addWhenPlayedAbility(properties: ITriggeredAbilityBaseProps): void {
+    protected addWhenPlayedAbility(properties: ITriggeredAbilityBaseProps<this>): void {
         const triggeredProperties = Object.assign(properties, { when: { onCardPlayed: (event, context) => event.card === context.source } });
         this.addTriggeredAbility(triggeredProperties);
     }
 
-    protected addWhenDefeatedAbility(properties: ITriggeredAbilityBaseProps): void {
+    protected addWhenDefeatedAbility(properties: ITriggeredAbilityBaseProps<this>): void {
         const triggeredProperties = Object.assign(properties, { when: { onCardDefeated: (event, context) => event.card === context.source } });
         this.addTriggeredAbility(triggeredProperties);
     }
@@ -99,12 +99,12 @@ export class InPlayCard extends PlayableOrDeployableCard {
         return { duration: Duration.Persistent, sourceLocationFilter, ...properties };
     }
 
-    public createReplacementEffectAbility(properties: IReplacementEffectAbilityProps): ReplacementEffectAbility {
+    public createReplacementEffectAbility(properties: IReplacementEffectAbilityProps<this>): ReplacementEffectAbility {
         properties.cardName = this.title;
         return new ReplacementEffectAbility(this.game, this, properties);
     }
 
-    public createTriggeredAbility(properties: ITriggeredAbilityProps): TriggeredAbility {
+    public createTriggeredAbility(properties: ITriggeredAbilityProps<this>): TriggeredAbility {
         properties.cardName = this.title;
         return new TriggeredAbility(this.game, this, properties);
     }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -5,7 +5,7 @@ import { IConstantAbility } from '../../ongoingEffect/IConstantAbility';
 import Player from '../../Player';
 import * as EnumHelpers from '../../utils/EnumHelpers';
 import { PlayableOrDeployableCard } from './PlayableOrDeployableCard';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import ReplacementEffectAbility from '../../ability/ReplacementEffectAbility';
 
 // required for mixins to be based on this class

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -1,7 +1,7 @@
 import PlayerOrCardAbility from '../../ability/PlayerOrCardAbility';
 import { CardType, EventName, Location } from '../../Constants';
 import Player from '../../Player';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import * as EnumHelpers from '../../utils/EnumHelpers';
 import { Card } from '../Card';
 

--- a/server/game/core/card/propertyMixins/Cost.ts
+++ b/server/game/core/card/propertyMixins/Cost.ts
@@ -1,4 +1,4 @@
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import { CardConstructor } from '../Card';
 
 /** Mixin function that adds the `cost` property to a base class. */

--- a/server/game/core/card/propertyMixins/Cost.ts
+++ b/server/game/core/card/propertyMixins/Cost.ts
@@ -4,10 +4,10 @@ import { CardConstructor } from '../Card';
 /** Mixin function that adds the `cost` property to a base class. */
 export function WithCost<TBaseClass extends CardConstructor>(BaseClass: TBaseClass) {
     return class WithCost extends BaseClass {
-        private readonly _printedCost: number;
+        public readonly printedCost: number;
 
         public get cost(): number {
-            return this._printedCost;
+            return this.printedCost;
         }
 
         // see Card constructor for list of expected args
@@ -16,7 +16,7 @@ export function WithCost<TBaseClass extends CardConstructor>(BaseClass: TBaseCla
             const [Player, cardData] = this.unpackConstructorArgs(...args);
 
             Contract.assertNotNullLike(cardData.cost);
-            this._printedCost = cardData.cost;
+            this.printedCost = cardData.cost;
         }
     };
 }

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -1,5 +1,5 @@
 import { Attack } from '../../attack/Attack';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import { Card, CardConstructor } from '../Card';
 import type { CardWithDamageProperty } from '../CardTypes';
 import { WithPrintedHp } from './PrintedHp';
@@ -43,18 +43,9 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
         }
 
         public addDamage(amount: number) {
-            if (!Contract.assertNotNullLikeOrNan(amount)) {
-                return;
-            }
+            Contract.assertNonNegative(amount);
 
             this.assertPropertyEnabled(this._damage, 'damage');
-            if (
-                !Contract.assertNotNullLikeOrNan(this.damage) ||
-                !Contract.assertNotNullLikeOrNan(this.hp) ||
-                !Contract.assertNonNegative(amount)
-            ) {
-                return;
-            }
 
             if (amount === 0) {
                 return;
@@ -74,14 +65,8 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
 
         /** @returns True if any damage was healed, false otherwise */
         public removeDamage(amount: number): boolean {
+            Contract.assertNonNegative(amount);
             this.assertPropertyEnabled(this._damage, 'damage');
-            if (
-                !Contract.assertNotNullLikeOrNan(this.damage) ||
-                !Contract.assertNotNullLikeOrNan(this.hp) ||
-                !Contract.assertNonNegative(amount)
-            ) {
-                return false;
-            }
 
             if (amount === 0 || this.damage === 0) {
                 return false;

--- a/server/game/core/card/propertyMixins/PrintedHp.ts
+++ b/server/game/core/card/propertyMixins/PrintedHp.ts
@@ -1,4 +1,4 @@
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import { CardConstructor } from '../Card';
 import type { WithDamage } from './Damage';
 

--- a/server/game/core/card/propertyMixins/PrintedPower.ts
+++ b/server/game/core/card/propertyMixins/PrintedPower.ts
@@ -1,4 +1,4 @@
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import { CardConstructor } from '../Card';
 
 /** Mixin function that adds the `printedPower` property to a base class. */

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -2,7 +2,7 @@ import { InitiateAttackAction } from '../../../actions/InitiateAttackAction';
 import { Arena, CardType, EffectName, KeywordName, Location, StatType } from '../../Constants';
 import StatsModifierWrapper from '../../ongoingEffect/effectImpl/StatsModifierWrapper';
 import { IOngoingCardEffect } from '../../ongoingEffect/IOngoingCardEffect';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import { InPlayCard, InPlayCardConstructor } from '../baseClasses/InPlayCard';
 import { WithDamage } from './Damage';
 import { WithPrintedPower } from './PrintedPower';
@@ -156,12 +156,10 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
          * These should be unregistered after the end of the attack.
          */
         public registerWhenPlayedKeywords() {
-            if (!Contract.assertTrue(
+            Contract.assertTrue(
                 this._whenPlayedKeywordAbilities === null,
                 `Failed to unregister when played abilities from previous play: ${this._whenPlayedKeywordAbilities?.map((ability) => ability.title).join(', ')}`
-            )) {
-                return;
-            }
+            );
 
             this._whenPlayedKeywordAbilities = [];
 
@@ -186,12 +184,10 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
          * These should be unregistered after the end of the attack.
          */
         public unregisterWhenPlayedKeywords() {
-            if (!Contract.assertTrue(
+            Contract.assertTrue(
                 Array.isArray(this._whenPlayedKeywordAbilities),
                 'Ability when played registration was skipped'
-            )) {
-                return;
-            }
+            );
 
             for (const ability of this._whenPlayedKeywordAbilities) {
                 if (ability instanceof TriggeredAbility) {
@@ -211,12 +207,10 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
          *      and the defeat all shields portion of Saboteur.
          */
         public registerAttackKeywords() {
-            if (!Contract.assertTrue(
+            Contract.assertTrue(
                 this._attackKeywordAbilities === null,
                 `Failed to unregister attack abilities from previous attack: ${this._attackKeywordAbilities?.map((ability) => ability.title).join(', ')}`
-            )) {
-                return;
-            }
+            );
 
             this._attackKeywordAbilities = [];
 
@@ -240,12 +234,10 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
          * These should be unregistered after the end of the attack.
          */
         public unregisterAttackKeywords() {
-            if (!Contract.assertTrue(
+            Contract.assertTrue(
                 Array.isArray(this._attackKeywordAbilities),
                 'Ability attack registration was skipped'
-            )) {
-                return;
-            }
+            );
 
             for (const ability of this._attackKeywordAbilities) {
                 if (ability instanceof TriggeredAbility) {
@@ -325,12 +317,8 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
          * Add the passed card to this card's upgrade list. Upgrade must already be moved to the correct arena.
          */
         public attachUpgrade(upgrade) {
-            if (
-                !Contract.assertEqual(upgrade.location, this.location) ||
-                !Contract.assertTrue(this.controller.getCardPile(this.location).includes(upgrade))
-            ) {
-                return;
-            }
+            Contract.assertEqual(upgrade.location, this.location);
+            Contract.assertTrue(this.controller.getCardPile(this.location).includes(upgrade));
 
             this._upgrades.push(upgrade);
         }

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -101,7 +101,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             return false;
         }
 
-        protected addOnAttackAbility(properties:Omit<ITriggeredAbilityProps, 'when' | 'aggregateWhen'>): void {
+        protected addOnAttackAbility(properties:Omit<ITriggeredAbilityProps<this>, 'when' | 'aggregateWhen'>): void {
             const triggeredProperties = Object.assign(properties, { when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source } });
             this.addTriggeredAbility(triggeredProperties);
         }

--- a/server/game/core/cardSelector/BaseCardSelector.js
+++ b/server/game/core/cardSelector/BaseCardSelector.js
@@ -1,16 +1,10 @@
 const { Location, RelativePlayer, WildcardLocation } = require('../Constants');
-const { default: Contract } = require('../utils/Contract');
+const Contract = require('../utils/Contract');
 const EnumHelpers = require('../utils/EnumHelpers');
 
 // TODO: once converted to TS, make this abstract
 class BaseCardSelector {
     constructor(properties) {
-        // TODO: remove this once we feel confident we've finished the rename pass successfully
-        if (!Contract.assertFalse('location' in properties, 'Attempting to create an effect with the \'location\' property, instead should be using the \'locationFilter\' property')) {
-            // just to catch any accidental use of the 'location' property we missed when doing the refactor to naming 'locationFilter'
-            throw Error('Attempting to create an effect with the \'location\' property, instead should be using the \'locationFilter\' property');
-        }
-
         this.cardCondition = properties.cardCondition;
         this.cardTypeFilter = properties.cardTypeFilter;
         this.optional = properties.optional;

--- a/server/game/core/event/EventWindow.js
+++ b/server/game/core/event/EventWindow.js
@@ -2,7 +2,7 @@ const { BaseStepWithPipeline } = require('../gameSteps/BaseStepWithPipeline.js')
 const { TriggeredAbilityWindow } = require('../gameSteps/abilityWindow/TriggeredAbilityWindow');
 const { SimpleStep } = require('../gameSteps/SimpleStep.js');
 const { AbilityType } = require('../Constants.js');
-const { default: Contract } = require('../utils/Contract.js');
+const Contract = require('../utils/Contract.js');
 const { GameEvent } = require('./GameEvent.js');
 
 class EventWindow extends BaseStepWithPipeline {

--- a/server/game/core/gameSteps/SimpleStep.ts
+++ b/server/game/core/gameSteps/SimpleStep.ts
@@ -1,5 +1,5 @@
 import type Game from '../Game';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { BaseStep } from './BaseStep';
 
 export class SimpleStep extends BaseStep {

--- a/server/game/core/gameSteps/abilityWindow/TriggeredAbilityWindow.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggeredAbilityWindow.ts
@@ -2,7 +2,7 @@ import Player from '../../Player';
 import { GameEvent } from '../../event/GameEvent';
 import EventWindow from '../../event/EventWindow';
 import { AbilityType, WildcardLocation } from '../../Constants';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import { TriggeredAbilityContext } from '../../ability/TriggeredAbilityContext';
 import TriggeredAbility from '../../ability/TriggeredAbility';
 import { Card } from '../../card/Card';
@@ -103,15 +103,11 @@ export class TriggeredAbilityWindow extends BaseStep {
     }
 
     protected assertWindowResolutionNotStarted(triggerTypeName: string, source: Card) {
-        if (!Contract.assertFalse(this.choosePlayerResolutionOrderComplete, `Attempting to add new triggered ${triggerTypeName} from source '${source.internalName}' to a window that has already started resolution`)) {
-            return;
-        }
+        Contract.assertFalse(this.choosePlayerResolutionOrderComplete, `Attempting to add new triggered ${triggerTypeName} from source '${source.internalName}' to a window that has already started resolution`);
     }
 
     private promptUnresolvedAbilities() {
-        if (!Contract.assertNotNullLike(this.currentlyResolvingPlayer)) {
-            return false;
-        }
+        Contract.assertNotNullLike(this.currentlyResolvingPlayer);
 
         this.choosePlayerResolutionOrderComplete = true;
 
@@ -154,12 +150,8 @@ export class TriggeredAbilityWindow extends BaseStep {
 
     /** Get the set of yet-unresolved abilities for the player whose turn it is to do resolution */
     private getCurrentlyResolvingAbilities() {
-        if (
-            !Contract.assertNotNullLike(this.currentlyResolvingPlayer) ||
-            !Contract.assertHasKey(this.unresolved, this.currentlyResolvingPlayer)
-        ) {
-            return null;
-        }
+        Contract.assertNotNullLike(this.currentlyResolvingPlayer);
+        Contract.assertHasKey(this.unresolved, this.currentlyResolvingPlayer);
 
         return this.unresolved.get(this.currentlyResolvingPlayer);
     }
@@ -227,9 +219,7 @@ export class TriggeredAbilityWindow extends BaseStep {
         const abilitiesAvailableForPlayer = this.getCurrentlyResolvingAbilities();
 
         for (const abilityContext of abilitiesAvailableForPlayer) {
-            if (!Contract.assertNotNullLike(abilityContext.source)) {
-                continue;
-            }
+            Contract.assertNotNullLike(abilityContext.source);
             triggeringCards.add(abilityContext.source);
         }
 
@@ -295,9 +285,7 @@ export class TriggeredAbilityWindow extends BaseStep {
      * in which case one of those will be selected randomly.
      */
     private consolidateShieldTriggers() {
-        if (!Contract.assertEqual(this.triggerAbilityType, AbilityType.ReplacementEffect)) {
-            return;
-        }
+        Contract.assertEqual(this.triggerAbilityType, AbilityType.ReplacementEffect);
 
         const postConsolidateUnresolved = new Map<Player, TriggeredAbilityContext[]>();
 

--- a/server/game/core/gameSteps/prompts/ResourcePrompt.ts
+++ b/server/game/core/gameSteps/prompts/ResourcePrompt.ts
@@ -1,7 +1,7 @@
 import { Card } from '../../card/Card';
 import type Game from '../../Game';
 import type Player from '../../Player';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import { AllPlayerPrompt } from './AllPlayerPrompt';
 
 export class ResourcePrompt extends AllPlayerPrompt {
@@ -60,10 +60,8 @@ export class ResourcePrompt extends AllPlayerPrompt {
     }
 
     public override onCardClicked(player: Player, card: Card) {
-        if (!Contract.assertNotNullLike(player) ||
-            !Contract.assertNotNullLike(card)) {
-            return false;
-        }
+        Contract.assertNotNullLike(player);
+        Contract.assertNotNullLike(card);
 
         if (!this.activeCondition(player)) {
             return false;

--- a/server/game/core/gameSteps/prompts/UiPrompt.ts
+++ b/server/game/core/gameSteps/prompts/UiPrompt.ts
@@ -1,7 +1,7 @@
 import { v1 as uuid } from 'uuid';
 import type Player from '../../Player';
 import { BaseStep } from '../BaseStep';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 
 interface ActivePrompt {
     buttons: { text: string; arg?: string; command?: string }[];
@@ -71,9 +71,7 @@ export abstract class UiPrompt extends BaseStep {
     }
 
     private addDefaultCommandToButtons(original?: ActivePrompt) {
-        if (!Contract.assertNotNullLike(original)) {
-            return null;
-        }
+        Contract.assertNotNullLike(original);
 
         const newPrompt = { ...original };
         if (newPrompt.buttons) {

--- a/server/game/core/gameSteps/prompts/VariableResourcePrompt.ts
+++ b/server/game/core/gameSteps/prompts/VariableResourcePrompt.ts
@@ -1,6 +1,6 @@
 import Game from '../../Game';
 import type Player from '../../Player';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 import { ResourcePrompt } from './ResourcePrompt';
 
 export class VariableResourcePrompt extends ResourcePrompt {

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -17,7 +17,7 @@ export interface ICardTargetSystemProperties extends IGameSystemProperties {
  */
 // TODO: mixin for Action types (CardAction, PlayerAction)?
 // TODO: could we remove the default generic parameter so that all child classes are forced to declare it
-export abstract class CardTargetSystem<TProperties extends ICardTargetSystemProperties = ICardTargetSystemProperties> extends GameSystem<TProperties> {
+export abstract class CardTargetSystem<TContext extends AbilityContext = AbilityContext, TProperties extends ICardTargetSystemProperties = ICardTargetSystemProperties> extends GameSystem<TContext, TProperties> {
     /** The set of card types that can be legally targeted by the system. Defaults to {@link WildcardCardType.Any} unless overriden. */
     protected readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Any];
 
@@ -29,7 +29,7 @@ export abstract class CardTargetSystem<TProperties extends ICardTargetSystemProp
         return EnumHelpers.cardTypeMatches(target.type, this.targetTypeFilter);
     }
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
         const { target } = this.generatePropertiesFromContext(context, additionalProperties);
         for (const card of Helpers.asArray(target)) {
             let allCostsPaid = true;
@@ -124,20 +124,20 @@ export abstract class CardTargetSystem<TProperties extends ICardTargetSystemProp
         return this.canAffect(event.card, event.context, additionalProperties);
     }
 
-    protected override addPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties = {}): void {
+    protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties = {}): void {
         super.addPropertiesToEvent(event, card, context, additionalProperties);
         event.card = card;
     }
 
-    public override isEventFullyResolved(event, card: Card, context: AbilityContext, additionalProperties): boolean {
+    public override isEventFullyResolved(event, card: Card, context: TContext, additionalProperties): boolean {
         return event.card === card && super.isEventFullyResolved(event, card, context, additionalProperties);
     }
 
-    protected override defaultTargets(context: AbilityContext): Card[] {
+    protected override defaultTargets(context: TContext): Card[] {
         return [context.source];
     }
 
-    protected addLeavesPlayPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+    protected addLeavesPlayPropertiesToEvent(event, card: Card, context: TContext, additionalProperties): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties) as any;
         super.updateEvent(event, card, context, additionalProperties);
         event.destination = properties.destination || Location.Discard;

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -5,7 +5,7 @@ import { GameSystem as GameSystem, IGameSystemProperties as IGameSystemPropertie
 import { GameEvent } from '../event/GameEvent';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import { UpgradeCard } from '../card/UpgradeCard';
-import { DefeatCardSystem } from '../../gameSystems/DefeatCardSystem';
+import * as Helpers from '../utils/Helpers';
 // import { LoseFateAction } from './LoseFateAction';
 
 export interface ICardTargetSystemProperties extends IGameSystemProperties {
@@ -26,12 +26,12 @@ export abstract class CardTargetSystem<TProperties extends ICardTargetSystemProp
             return false;
         }
 
-        return EnumHelpers.cardTypeMatches((target as Card).type, this.targetTypeFilter);
+        return EnumHelpers.cardTypeMatches(target.type, this.targetTypeFilter);
     }
 
     public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
         const { target } = this.generatePropertiesFromContext(context, additionalProperties);
-        for (const card of target as Card[]) {
+        for (const card of Helpers.asArray(target)) {
             let allCostsPaid = true;
             const additionalCosts = card
                 .getEffectValues(EffectName.UnlessActionCost)

--- a/server/game/core/gameSystem/LastingEffectSystem.ts
+++ b/server/game/core/gameSystem/LastingEffectSystem.ts
@@ -21,7 +21,7 @@ export interface LastingEffectProperties extends ILastingEffectGeneralProperties
 
 // TODO: how is this related to CardLastingEffectSystem?
 /** @deprecated this has not been tried yet */
-export class LastingEffectAction extends GameSystem<LastingEffectProperties> {
+export class LastingEffectAction<TContext extends AbilityContext = AbilityContext> extends GameSystem<TContext, LastingEffectProperties> {
     public override readonly name = 'applyLastingEffect';
     public override readonly eventName = EventName.OnEffectApplied;
     public override readonly effectDescription = 'apply a lasting effect';
@@ -35,7 +35,7 @@ export class LastingEffectAction extends GameSystem<LastingEffectProperties> {
     }
 
     public override generatePropertiesFromContext(
-        context: AbilityContext,
+        context: TContext,
         additionalProperties = {}
     ): LastingEffectProperties & { effect?: OngoingEffect[] } {
         const properties = super.generatePropertiesFromContext(context, additionalProperties) as LastingEffectProperties & {
@@ -47,12 +47,12 @@ export class LastingEffectAction extends GameSystem<LastingEffectProperties> {
         return properties;
     }
 
-    public override hasLegalTarget(context: AbilityContext, additionalProperties = {}): boolean {
+    public override hasLegalTarget(context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.effect.length > 0;
     }
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties: any): void {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: any): void {
         if (this.hasLegalTarget(context, additionalProperties)) {
             events.push(this.generateEvent(null, context, additionalProperties));
         }

--- a/server/game/core/gameSystem/MetaSystem.ts
+++ b/server/game/core/gameSystem/MetaSystem.ts
@@ -1,0 +1,13 @@
+import { AbilityContext } from '../ability/AbilityContext';
+import { Card } from '../card/Card';
+import { GameSystem, IGameSystemProperties } from './GameSystem';
+
+/**
+ * Meta-system used for executing a set of other systems together.
+ *
+ * @template TContext Type of {@link AbilityContext} that this system uses for any method that accepts a context
+ */
+export abstract class MetaSystem<TContext extends AbilityContext = AbilityContext, TProperties extends IGameSystemProperties = IGameSystemProperties> extends GameSystem<TProperties> {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public override eventHandler() {}
+}

--- a/server/game/core/gameSystem/MetaSystem.ts
+++ b/server/game/core/gameSystem/MetaSystem.ts
@@ -7,7 +7,7 @@ import { GameSystem, IGameSystemProperties } from './GameSystem';
  *
  * @template TContext Type of {@link AbilityContext} that this system uses for any method that accepts a context
  */
-export abstract class MetaSystem<TContext extends AbilityContext = AbilityContext, TProperties extends IGameSystemProperties = IGameSystemProperties> extends GameSystem<TProperties> {
+export abstract class MetaSystem<TContext extends AbilityContext = AbilityContext, TProperties extends IGameSystemProperties = IGameSystemProperties> extends GameSystem<TContext, TProperties> {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public override eventHandler() {}
 }

--- a/server/game/core/gameSystem/PlayerTargetSystem.ts
+++ b/server/game/core/gameSystem/PlayerTargetSystem.ts
@@ -8,12 +8,12 @@ export interface IPlayerTargetSystemProperties extends IGameSystemProperties {}
 /**
  * A {@link GameSystem} which targets a player for its effect
  */
-export abstract class PlayerTargetSystem<TProperties extends IPlayerTargetSystemProperties = IPlayerTargetSystemProperties> extends GameSystem<TProperties> {
+export abstract class PlayerTargetSystem<TContext extends AbilityContext = AbilityContext, TProperties extends IPlayerTargetSystemProperties = IPlayerTargetSystemProperties> extends GameSystem<TContext, TProperties> {
     protected override isTargetTypeValid(target: any): boolean {
         return target instanceof Player;
     }
 
-    public override defaultTargets(context: AbilityContext): Player[] {
+    public override defaultTargets(context: TContext): Player[] {
         return context.player ? [context.player.opponent] : [];
     }
 
@@ -21,7 +21,7 @@ export abstract class PlayerTargetSystem<TProperties extends IPlayerTargetSystem
         return this.canAffect(event.player, event.context, additionalProperties);
     }
 
-    protected override addPropertiesToEvent(event, player: Player, context: AbilityContext, additionalProperties = {}): void {
+    protected override addPropertiesToEvent(event, player: Player, context: TContext, additionalProperties = {}): void {
         super.addPropertiesToEvent(event, player, context, additionalProperties);
         event.player = player;
     }

--- a/server/game/core/ongoingEffect/OngoingCardEffect.js
+++ b/server/game/core/ongoingEffect/OngoingCardEffect.js
@@ -1,7 +1,7 @@
 const OngoingEffect = require('./OngoingEffect.js');
 const { RelativePlayer, WildcardLocation, WildcardCardType } = require('../Constants.js');
 const EnumHelpers = require('../utils/EnumHelpers.js');
-const { default: Contract } = require('../utils/Contract.js');
+const Contract = require('../utils/Contract.js');
 const Helpers = require('../utils/Helpers.js');
 
 // TODO: confusingly, this is not an implementation of IOngoingCardEffect. what's the relationship supposed to be?

--- a/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
@@ -27,7 +27,7 @@ interface Props {
     target?: PlayerOrCard | PlayerOrCard[];
     cannotBeCancelled?: boolean;
     optional?: boolean;
-    parentAction?: GameSystem;
+    parentSystem?: GameSystem;
 }
 
 /* Types of effect

--- a/server/game/core/ongoingEffect/OngoingEffectSource.js
+++ b/server/game/core/ongoingEffect/OngoingEffectSource.js
@@ -3,7 +3,7 @@ const { GameObject } = require('../GameObject.js');
 
 const { Duration, WildcardLocation } = require('../Constants.js');
 const OngoingEffect = require('./OngoingEffect.js');
-const { default: Contract } = require('../utils/Contract.js');
+const Contract = require('../utils/Contract.js');
 
 // This class is inherited by Card and also represents Framework effects
 
@@ -42,11 +42,6 @@ class OngoingEffectSource extends GameObject {
      * @returns {OngoingEffect[]} the effect(s) that were added to the engine
      */
     addEffectToEngine(properties) {
-        if (!Contract.assertFalse('location' in properties, 'Attempting to create an effect with the \'location\' property, instead should be using the \'locationFilter\' property.')) {
-            // just to catch any accidental use of the 'location' property we missed when doing the refactor to naming 'locationFilter'
-            throw Error('Attempting to create an effect with the \'location\' property, instead should be using the \'locationFilter\' property');
-        }
-
         let ongoingEffect = properties.ongoingEffect;
 
         let propertiesWithoutEffect;

--- a/server/game/core/ongoingEffect/effectImpl/StatsModifierWrapper.ts
+++ b/server/game/core/ongoingEffect/effectImpl/StatsModifierWrapper.ts
@@ -7,7 +7,7 @@ import { StatsModifier } from './StatsModifier';
 import { LeaderUnitCard } from '../../card/LeaderUnitCard';
 import { NonLeaderUnitCard } from '../../card/NonLeaderUnitCard';
 import { UnitPropertiesCard } from '../../card/propertyMixins/UnitProperties';
-import Contract from '../../utils/Contract';
+import * as Contract from '../../utils/Contract';
 
 /**
  * A wrapper around a {@link StatsModifier} that has helper methods for creation as well
@@ -59,18 +59,14 @@ export default class StatsModifierWrapper {
     }
 
     public static fromPrintedValues(card: Card, overrides = false) {
-        if (
-            !Contract.assertHasProperty(card, 'printedHp') ||
-            !Contract.assertHasProperty(card, 'printedPower')
-        ) {
-            return null;
-        }
+        Contract.assertHasProperty(card, 'printedHp');
+        Contract.assertHasProperty(card, 'printedPower');
 
         const description = card.isUpgrade() ? `${card.name} bonus` : `${card.name} base`;
 
         return new this({
-            hp: (card as CardWithPrintedHp).printedHp,
-            power: (card as CardWithPrintedPower).printedPower
+            hp: card.printedHp,
+            power: card.printedPower
         },
         description,
         overrides,

--- a/server/game/core/stateWatcher/StateWatcher.ts
+++ b/server/game/core/stateWatcher/StateWatcher.ts
@@ -2,7 +2,7 @@ import { IStateListenerResetProperties, IStateListenerProperties } from '../../I
 import { Card } from '../card/Card';
 import { PhaseName, StateWatcherName } from '../Constants';
 import Player from '../Player';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 import { StateWatcherRegistrar } from './StateWatcherRegistrar';
 
 /**
@@ -65,11 +65,7 @@ export abstract class StateWatcher<TState> {
     private generateListenerRegistrations(): IStateListenerProperties<TState>[] {
         this.setupWatcher();
 
-        if (
-            !Contract.assertTrue(this.stateUpdaters.length > 0, 'No state updaters registered')
-        ) {
-            return [];
-        }
+        Contract.assertTrue(this.stateUpdaters.length > 0, 'No state updaters registered');
 
         const stateResetUpdater: IStateListenerProperties<TState> =
             Object.assign(this.stateResetTrigger, { update: () => this.getResetValue() });

--- a/server/game/core/stateWatcher/StateWatcherRegistrar.ts
+++ b/server/game/core/stateWatcher/StateWatcherRegistrar.ts
@@ -1,7 +1,7 @@
 import { IStateListenerProperties } from '../../Interfaces';
 import Game from '../Game';
 import Player from '../Player';
-import Contract from '../utils/Contract';
+import * as Contract from '../utils/Contract';
 
 /**
  * Helper for managing the operation of {@link StateWatcher} implementations.
@@ -57,12 +57,8 @@ export class StateWatcherRegistrar {
     }
 
     private assertRegistered(watcherKey: string) {
-        if (
-            !Contract.assertTrue(this.isRegistered(watcherKey),
-                `Watcher '${watcherKey}' not found in registered watcher list: ${Array.from(this.watchedState.keys()).join(', ')}`)
-        ) {
-            return false;
-        }
+        Contract.assertTrue(this.isRegistered(watcherKey),
+            `Watcher '${watcherKey}' not found in registered watcher list: ${Array.from(this.watchedState.keys()).join(', ')}`);
 
         return true;
     }

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -1,6 +1,6 @@
 import { Card } from '../card/Card';
 import { Aspect, CardType, CardTypeFilter, Location } from '../Constants';
-import Contract from './Contract';
+import * as Contract from './Contract';
 import * as EnumHelpers from './EnumHelpers';
 
 /* Randomize array in-place using Durstenfeld shuffle algorithm */

--- a/server/game/costs/PlayCardResourceCost.ts
+++ b/server/game/costs/PlayCardResourceCost.ts
@@ -17,7 +17,7 @@ export class PlayCardResourceCost implements ICost {
     public constructor(public ignoreType: boolean) {}
 
     public canPay(context: AbilityContext): boolean {
-        if (context.source.printedCost === null) {
+        if (!('printedCost' in context.source)) {
             return false;
         }
 

--- a/server/game/gameSystems/AttachUpgradeSystem.ts
+++ b/server/game/gameSystems/AttachUpgradeSystem.ts
@@ -14,7 +14,7 @@ export interface IAttachUpgradeProperties extends ICardTargetSystemProperties {
     controlSwitchOptional?: boolean;
 }
 
-export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperties> {
+export class AttachUpgradeSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IAttachUpgradeProperties> {
     public override readonly name = 'attach';
     public override readonly eventName = EventName.OnUpgradeAttached;
     protected override readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Unit];
@@ -45,7 +45,7 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
         }
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
         if (properties.takeControl) {
             return [
@@ -61,7 +61,7 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
         return ['attach {1} to {0}', [properties.target, properties.upgrade]];
     }
 
-    public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const contextCopy = context.copy({ source: card });
 
@@ -97,12 +97,12 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
         return this.canAffect(event.parentCard, event.context, additionalProperties);
     }
 
-    public override isEventFullyResolved(event, card: Card, context: AbilityContext, additionalProperties): boolean {
+    public override isEventFullyResolved(event, card: Card, context: TContext, additionalProperties): boolean {
         const { upgrade } = this.generatePropertiesFromContext(context, additionalProperties);
         return event.parentCard === card && event.card === upgrade && event.name === this.eventName && !event.cancelled;
     }
 
-    protected override addPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+    protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties): void {
         const { upgrade } = this.generatePropertiesFromContext(context, additionalProperties);
         event.name = this.eventName;
         event.parentCard = card;

--- a/server/game/gameSystems/AttachUpgradeSystem.ts
+++ b/server/game/gameSystems/AttachUpgradeSystem.ts
@@ -4,7 +4,7 @@ import { UnitCard } from '../core/card/CardTypes';
 import { UpgradeCard } from '../core/card/UpgradeCard';
 import { AbilityRestriction, CardTypeFilter, EventName, WildcardCardType } from '../core/Constants';
 import { CardTargetSystem, ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
-import Contract from '../core/utils/Contract';
+import * as Contract from '../core/utils/Contract';
 import * as EnumHelpers from '../core/utils/EnumHelpers';
 
 export interface IAttachUpgradeProperties extends ICardTargetSystemProperties {
@@ -24,9 +24,9 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
     };
 
     public override eventHandler(event, additionalProperties = {}): void {
-        if (!Contract.assertTrue(event.card.isUpgrade()) || !Contract.assertTrue(event.parentCard.isUnit())) {
-            return;
-        }
+        // TODO THIS PR: type for event.card
+        Contract.assertTrue(event.card.isUpgrade());
+        Contract.assertTrue(event.parentCard.isUnit());
 
         const properties = this.generatePropertiesFromContext(event.context, additionalProperties);
         event.originalLocation = event.card.location;
@@ -63,14 +63,10 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const contextCopy = context.copy({ source: card });
 
-        if (
-            !Contract.assertNotNullLike(context) ||
-            !Contract.assertNotNullLike(context.player) ||
-            !Contract.assertNotNullLike(card) ||
-            !Contract.assertNotNullLike(properties.upgrade)
-        ) {
-            return false;
-        }
+        Contract.assertNotNullLike(context);
+        Contract.assertNotNullLike(context.player);
+        Contract.assertNotNullLike(card);
+        Contract.assertNotNullLike(properties.upgrade);
 
         if (!card.isUnit()) {
             return false;

--- a/server/game/gameSystems/AttachUpgradeSystem.ts
+++ b/server/game/gameSystems/AttachUpgradeSystem.ts
@@ -27,8 +27,6 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
         const upgradeCard = (event.card as Card);
         const parentCard = (event.parentCard as Card);
 
-        Contract.assertNotNullLike(upgradeCard);
-        Contract.assertNotNullLike(parentCard);
         Contract.assertTrue(upgradeCard.isUpgrade());
         Contract.assertTrue(parentCard.isUnit());
 

--- a/server/game/gameSystems/AttachUpgradeSystem.ts
+++ b/server/game/gameSystems/AttachUpgradeSystem.ts
@@ -24,22 +24,26 @@ export class AttachUpgradeSystem extends CardTargetSystem<IAttachUpgradeProperti
     };
 
     public override eventHandler(event, additionalProperties = {}): void {
-        // TODO THIS PR: type for event.card
-        Contract.assertTrue(event.card.isUpgrade());
-        Contract.assertTrue(event.parentCard.isUnit());
+        const upgradeCard = (event.card as Card);
+        const parentCard = (event.parentCard as Card);
+
+        Contract.assertNotNullLike(upgradeCard);
+        Contract.assertNotNullLike(parentCard);
+        Contract.assertTrue(upgradeCard.isUpgrade());
+        Contract.assertTrue(parentCard.isUnit());
 
         const properties = this.generatePropertiesFromContext(event.context, additionalProperties);
-        event.originalLocation = event.card.location;
+        event.originalLocation = upgradeCard.location;
 
         // attachTo manages all of the unattach and move zone logic
-        event.card.attachTo(event.parentCard);
+        upgradeCard.attachTo(parentCard);
 
         if (properties.takeControl) {
-            event.card.controller = event.context.player;
-            event.card.updateConstantAbilityContexts();
+            upgradeCard.controller = event.context.player;
+            upgradeCard.updateConstantAbilityContexts();
         } else if (properties.giveControl) {
-            event.card.controller = event.context.player.opponent;
-            event.card.updateConstantAbilityContexts();
+            upgradeCard.controller = event.context.player.opponent;
+            upgradeCard.updateConstantAbilityContexts();
         }
     }
 

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -11,7 +11,7 @@ import type { Card } from '../core/card/Card';
 import { isArray } from 'underscore';
 import { GameEvent } from '../core/event/GameEvent';
 import { ICardLastingEffectProperties, CardLastingEffectSystem } from './CardLastingEffectSystem';
-import Contract from '../core/utils/Contract';
+import * as Contract from '../core/utils/Contract';
 import { CardWithDamageProperty, UnitCard } from '../core/card/CardTypes';
 import * as Helpers from '../core/utils/Helpers';
 
@@ -104,11 +104,10 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
         }
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        if (
-            !Contract.assertNotNullLike(properties.attacker) ||
-            !Contract.assertTrue(properties.attacker.isUnit()) ||
-            !EnumHelpers.isArena(properties.attacker.location)
-        ) {
+        Contract.assertNotNullLike(properties.attacker);
+        Contract.assertTrue(properties.attacker.isUnit());
+
+        if (!EnumHelpers.isArena(properties.attacker.location)) {
             return false;
         }
         if (!super.canAffect(targetCard, context)) {
@@ -119,7 +118,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
         }
         if (
             targetCard.hasRestriction(AbilityRestriction.BeAttacked, context) ||
-            (properties.attacker as UnitCard).effectsPreventAttack(targetCard)
+            properties.attacker.effectsPreventAttack(targetCard)
         ) {
             return false; // cannot attack cards with a BeAttacked restriction
         }
@@ -172,9 +171,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
     protected override addPropertiesToEvent(event, target, context: AbilityContext, additionalProperties): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
-        if (!Contract.assertTrue(properties.attacker.isUnit(), `Attacking card '${properties.attacker.internalName}' is not a unit`)) {
-            return;
-        }
+        Contract.assertTrue(properties.attacker.isUnit(), `Attacking card '${properties.attacker.internalName}' is not a unit`);
 
         if (isArray(target)) {
             if (target.length !== 1) {
@@ -187,9 +184,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
             event.target = target;
         }
 
-        if (!Contract.assertTrue(event.target.isUnit() || event.target.isBase(), `Attack target card '${event.target.internalName}' is not a unit or base`)) {
-            return;
-        }
+        Contract.assertTrue(event.target.isUnit() || event.target.isBase(), `Attack target card '${event.target.internalName}' is not a unit or base`);
 
         event.context = context;
         event.attacker = properties.attacker;

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -158,7 +158,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
             additionalProperties
         );
 
-        const cards = (target as Card[]).filter((card) => this.canAffect(card, context));
+        const cards = Helpers.asArray(target).filter((card) => this.canAffect(card, context));
         if (cards.length !== 1) {
             return;
         }

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -15,43 +15,43 @@ import * as Contract from '../core/utils/Contract';
 import { CardWithDamageProperty, UnitCard } from '../core/card/CardTypes';
 import * as Helpers from '../core/utils/Helpers';
 
-export interface IAttackLastingEffectProperties {
-    condition?: (attack: Attack, context: AbilityContext) => boolean;
+export interface IAttackLastingEffectProperties<TContext extends AbilityContext = AbilityContext> {
+    condition?: (attack: Attack, context: TContext) => boolean;
     effect?: any;
 }
 
-type IAttackLastingEffectPropertiesOrFactory = IAttackLastingEffectProperties | ((context: AbilityContext, attack: Attack) => IAttackLastingEffectProperties);
+type IAttackLastingEffectPropertiesOrFactory<TContext extends AbilityContext = AbilityContext> = IAttackLastingEffectProperties<TContext> | ((context: TContext, attack: Attack) => IAttackLastingEffectProperties<TContext>);
 
-export interface IAttackProperties extends ICardTargetSystemProperties {
+export interface IAttackProperties<TContext extends AbilityContext = AbilityContext> extends ICardTargetSystemProperties {
     attacker?: Card;
-    targetCondition?: (card: Card, context: AbilityContext) => boolean;
+    targetCondition?: (card: Card, context: TContext) => boolean;
     message?: string;
-    messageArgs?: (attack: Attack, context: AbilityContext) => any | any[];
-    costHandler?: (context: AbilityContext, prompt: any) => void;
+    messageArgs?: (attack: Attack, context: TContext) => any | any[];
+    costHandler?: (context: TContext, prompt: any) => void;
 
     /**
      * Effects to apply to the attacker for the duration of the attack. Can be one or more {@link IAttackLastingEffectProperties}
      * or a function generator(s) for them.
      */
-    attackerLastingEffects?: IAttackLastingEffectPropertiesOrFactory | IAttackLastingEffectPropertiesOrFactory[];
+    attackerLastingEffects?: IAttackLastingEffectPropertiesOrFactory<TContext> | IAttackLastingEffectPropertiesOrFactory<TContext>[];
 
     // TODO: allow declaring multiple attackers (new Maul)
     /**
      * Effects to apply to the attacker for the duration of the attack. Can be one or more {@link IAttackLastingEffectProperties}
      * or a function generator(s) for them.
      */
-    defenderLastingEffects?: IAttackLastingEffectPropertiesOrFactory | IAttackLastingEffectPropertiesOrFactory[];
+    defenderLastingEffects?: IAttackLastingEffectPropertiesOrFactory<TContext> | IAttackLastingEffectPropertiesOrFactory<TContext>[];
 }
 
 /**
  * Manages the concrete steps of the attack process, emitting events at the appropriate stages.
  * Does not manage the exhaust cost. The attacker must already be selected and set via the `attacker` property.
  */
-export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
+export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IAttackProperties<TContext>> {
     public override readonly name = 'attack';
     public override readonly eventName = EventName.MetaAttackSteps;
     protected override readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Unit, CardType.Base];
-    protected override readonly defaultProperties: IAttackProperties = {
+    protected override readonly defaultProperties: IAttackProperties<TContext> = {
         targetCondition: () => true
     };
 
@@ -81,15 +81,15 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
         );
     }
 
-    public override generatePropertiesFromContext(context: AbilityContext, additionalProperties = {}): IAttackProperties {
-        const properties = super.generatePropertiesFromContext(context, additionalProperties) as IAttackProperties;
+    public override generatePropertiesFromContext(context: TContext, additionalProperties = {}) {
+        const properties = super.generatePropertiesFromContext(context, additionalProperties);
         if (!properties.attacker) {
             properties.attacker = context.source;
         }
         return properties;
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
         return [
             '{0} initiates attack against {1}',
@@ -98,7 +98,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
     }
 
     /** This method is checking whether cards are a valid target for an attack. */
-    public override canAffect(targetCard: Card, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(targetCard: Card, context: TContext, additionalProperties = {}): boolean {
         if (!('printedHp' in targetCard)) {
             return false; // cannot attack cards without printed HP
         }
@@ -147,12 +147,12 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
         );
     }
 
-    public attackCosts(prompt, context: AbilityContext, additionalProperties = {}): void {
+    public attackCosts(prompt, context: TContext, additionalProperties = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         properties.costHandler(context, prompt);
     }
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
         const { target } = this.generatePropertiesFromContext(
             context,
             additionalProperties
@@ -168,7 +168,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
         events.push(event);
     }
 
-    protected override addPropertiesToEvent(event, target, context: AbilityContext, additionalProperties): void {
+    protected override addPropertiesToEvent(event, target, context: TContext, additionalProperties): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
         Contract.assertTrue(properties.attacker.isUnit(), `Attacking card '${properties.attacker.internalName}' is not a unit`);
@@ -200,7 +200,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
         return this.canAffect(event.target, event.context, additionalProperties);
     }
 
-    private resolveAttack(attack: Attack, context: AbilityContext): void {
+    private resolveAttack(attack: Attack, context: TContext): void {
         // TODO: add more isValid() checks during the attack flow (if needed), and confirm that attack lasting effects still end correctly if any of them fail
         if (!attack.isValid()) {
             context.game.addMessage('The attack cannot proceed as the attacker or defender is no longer in play');
@@ -221,7 +221,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
     // TODO ATTACKS: change attack effects so that they check the specific attack they are affecting,
     // in case we have have a situation when multiple attacks are happening in parallel but an effect
     // only applies to one of them.
-    private registerAttackEffects(context: AbilityContext, properties: IAttackProperties, attack: Attack) {
+    private registerAttackEffects(context: TContext, properties: IAttackProperties, attack: Attack) {
         // create events for all effects to be generated
         const effectEvents: GameEvent[] = [];
         const effectsRegistered =
@@ -237,7 +237,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
     private queueCreateLastingEffectsGameSteps(
         lastingEffects: IAttackLastingEffectPropertiesOrFactory[],
         target: Card,
-        context: AbilityContext,
+        context: TContext,
         attack: Attack,
         effectEvents: GameEvent[]
     ): boolean {
@@ -251,7 +251,7 @@ export class AttackStepsSystem extends CardTargetSystem<IAttackProperties> {
             const effectSystem = new CardLastingEffectSystem(Object.assign({}, lastingEffectProperties, {
                 duration: Duration.UntilEndOfAttack,
                 target: target,
-                condition: lastingEffectProperties.condition == null ? null : (context: AbilityContext) => lastingEffectProperties.condition(attack, context)
+                condition: lastingEffectProperties.condition == null ? null : (context: TContext) => lastingEffectProperties.condition(attack, context)
             }));
             effectSystem.queueGenerateEventGameSteps(effectEvents, context);
         }

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -13,7 +13,7 @@ export interface ICardLastingEffectProperties extends Omit<ILastingEffectGeneral
  * For a definition, see SWU 7.7.3 'Lasting Effects': "A lasting effect is a part of an ability that affects the game for a specified duration of time.
  * Most lasting effects include the phrase 'for this phase' or 'for this attack.'"
  */
-export class CardLastingEffectSystem extends CardTargetSystem<ICardLastingEffectProperties> {
+export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, ICardLastingEffectProperties> {
     public override readonly name: string = 'applyCardLastingEffect';
     public override readonly eventName = EventName.OnEffectApplied;
     public override readonly effectDescription: string = 'apply a lasting effect to {0}';
@@ -45,7 +45,7 @@ export class CardLastingEffectSystem extends CardTargetSystem<ICardLastingEffect
         }
     }
 
-    public override generatePropertiesFromContext(context: AbilityContext, additionalProperties = {}): ICardLastingEffectProperties {
+    public override generatePropertiesFromContext(context: TContext, additionalProperties = {}): ICardLastingEffectProperties {
         const properties = super.generatePropertiesFromContext(context, additionalProperties);
         if (!Array.isArray(properties.effect)) {
             properties.effect = [properties.effect];
@@ -53,7 +53,7 @@ export class CardLastingEffectSystem extends CardTargetSystem<ICardLastingEffect
         return properties;
     }
 
-    public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         properties.effect = properties.effect.map((factory) => factory(context.game, context.source, properties));
         const lastingEffectRestrictions = card.getEffectValues(EffectName.CannotApplyLastingEffects);

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -19,7 +19,6 @@ export class CardLastingEffectSystem extends CardTargetSystem<ICardLastingEffect
     public override readonly effectDescription: string = 'apply a lasting effect to {0}';
     protected override readonly defaultProperties: ICardLastingEffectProperties = {
         duration: null,
-        // TODO THIS PR: rename to ongoingEffect
         effect: [],
         ability: null
     };

--- a/server/game/gameSystems/CardPhaseLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardPhaseLastingEffectSystem.ts
@@ -10,7 +10,7 @@ export type ICardPhaseLastingEffectProperties = Omit<ICardLastingEffectPropertie
  * Helper subclass of {@link CardLastingEffectSystem} that specifically creates lasting effects targeting cards
  * for the rest of the current phase.
  */
-export class CardPhaseLastingEffectSystem extends CardLastingEffectSystem {
+export class CardPhaseLastingEffectSystem<TContext extends AbilityContext = AbilityContext> extends CardLastingEffectSystem<TContext> {
     public override readonly name = 'applyCardPhaseLastingEffect';
     public override readonly eventName = EventName.OnEffectApplied;
     public override readonly effectDescription = 'apply an effect to {0} for the phase';

--- a/server/game/gameSystems/ConditionalSystem.ts
+++ b/server/game/gameSystems/ConditionalSystem.ts
@@ -1,24 +1,21 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { GameEvent } from '../core/event/GameEvent';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
+import { MetaSystem } from '../core/gameSystem/MetaSystem';
 
-export interface IConditionalSystemProperties extends IGameSystemProperties {
-    condition: ((context: AbilityContext, properties: IConditionalSystemProperties) => boolean) | boolean;
+export interface IConditionalSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
+    condition: ((context: TContext, properties: IConditionalSystemProperties) => boolean) | boolean;
     onTrue: GameSystem;
     onFalse: GameSystem;
 }
 
-export class ConditionalSystem extends GameSystem<IConditionalSystemProperties> {
+export class ConditionalSystem<TContext extends AbilityContext = AbilityContext> extends MetaSystem<TContext, IConditionalSystemProperties<TContext>> {
     public override generatePropertiesFromContext(context: AbilityContext, additionalProperties = {}): IConditionalSystemProperties {
         const properties = super.generatePropertiesFromContext(context, additionalProperties);
         properties.onTrue.setDefaultTargetFn(() => properties.target);
         properties.onFalse.setDefaultTargetFn(() => properties.target);
         return properties;
     }
-
-    // TODO: some GameSystem subclasses just generate events but don't themselves have eventHandlers, do we need to specialize for that case?
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    public eventHandler(target) {}
 
     public override getEffectMessage(context: AbilityContext): [string, any[]] {
         return this.getGameAction(context).getEffectMessage(context);

--- a/server/game/gameSystems/ConditionalSystem.ts
+++ b/server/game/gameSystems/ConditionalSystem.ts
@@ -5,42 +5,42 @@ import { MetaSystem } from '../core/gameSystem/MetaSystem';
 
 export interface IConditionalSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
     condition: ((context: TContext, properties: IConditionalSystemProperties) => boolean) | boolean;
-    onTrue: GameSystem;
-    onFalse: GameSystem;
+    onTrue: GameSystem<TContext>;
+    onFalse: GameSystem<TContext>;
 }
 
 export class ConditionalSystem<TContext extends AbilityContext = AbilityContext> extends MetaSystem<TContext, IConditionalSystemProperties<TContext>> {
-    public override generatePropertiesFromContext(context: AbilityContext, additionalProperties = {}): IConditionalSystemProperties {
+    public override generatePropertiesFromContext(context: TContext, additionalProperties = {}) {
         const properties = super.generatePropertiesFromContext(context, additionalProperties);
         properties.onTrue.setDefaultTargetFn(() => properties.target);
         properties.onFalse.setDefaultTargetFn(() => properties.target);
         return properties;
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         return this.getGameAction(context).getEffectMessage(context);
     }
 
-    public override canAffect(target: any, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(target: any, context: TContext, additionalProperties = {}): boolean {
         return this.getGameAction(context, additionalProperties).canAffect(target, context, additionalProperties);
     }
 
-    public override hasLegalTarget(context: AbilityContext, additionalProperties = {}): boolean {
+    public override hasLegalTarget(context: TContext, additionalProperties = {}): boolean {
         return this.getGameAction(context, additionalProperties).hasLegalTarget(context, additionalProperties);
     }
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
         this.getGameAction(context, additionalProperties).queueGenerateEventGameSteps(events, context, additionalProperties);
     }
 
-    public override hasTargetsChosenByInitiatingPlayer(context: AbilityContext, additionalProperties = {}): boolean {
+    public override hasTargetsChosenByInitiatingPlayer(context: TContext, additionalProperties = {}): boolean {
         return this.getGameAction(context, additionalProperties).hasTargetsChosenByInitiatingPlayer(
             context,
             additionalProperties
         );
     }
 
-    private getGameAction(context: AbilityContext, additionalProperties = {}): GameSystem {
+    private getGameAction(context: TContext, additionalProperties = {}) {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         let condition = properties.condition;
         if (typeof condition === 'function') {

--- a/server/game/gameSystems/DamageSystem.ts
+++ b/server/game/gameSystems/DamageSystem.ts
@@ -12,7 +12,7 @@ export interface IDamageProperties extends ICardTargetSystemProperties {
 // TODO: for this and the heal system, need to figure out how to handle the situation where 0 damage
 // is dealt / healed. Since the card is technically still a legal target but no damage was technically
 // dealt / healed per the rules (SWU 8.31.3)
-export class DamageSystem extends CardTargetSystem<IDamageProperties> {
+export class DamageSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IDamageProperties> {
     public override readonly name = 'damage';
     public override readonly eventName = EventName.OnDamageDealt;
 
@@ -22,7 +22,7 @@ export class DamageSystem extends CardTargetSystem<IDamageProperties> {
         event.card.addDamage(event.damage);
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const { amount, target, isCombatDamage } = this.generatePropertiesFromContext(context);
 
         if (isCombatDamage) {
@@ -31,7 +31,7 @@ export class DamageSystem extends CardTargetSystem<IDamageProperties> {
         return ['deal {1} damage to {0}', [amount, target]];
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         if (!EnumHelpers.isAttackableLocation(card.location)) {
             return false;
         }
@@ -41,7 +41,7 @@ export class DamageSystem extends CardTargetSystem<IDamageProperties> {
         return super.canAffect(card, context);
     }
 
-    protected override addPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+    protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties): void {
         const { amount, isCombatDamage } = this.generatePropertiesFromContext(context, additionalProperties) as IDamageProperties;
         super.addPropertiesToEvent(event, card, context, additionalProperties);
         event.damage = amount;

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -7,7 +7,7 @@ import * as EnumHelpers from '../core/utils/EnumHelpers';
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IDefeatCardProperties extends ICardTargetSystemProperties {}
 
-export class DefeatCardSystem extends CardTargetSystem<IDefeatCardProperties> {
+export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IDefeatCardProperties> {
     public override readonly name = 'defeat';
     public override readonly eventName = EventName.OnCardDefeated;
     public override readonly costDescription = 'defeating {0}';
@@ -33,19 +33,19 @@ export class DefeatCardSystem extends CardTargetSystem<IDefeatCardProperties> {
         }
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
         return ['defeat {0}', [properties.target]];
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         if (!EnumHelpers.isArena(card.location)) {
             return false;
         }
         return super.canAffect(card, context);
     }
 
-    protected override updateEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+    protected override updateEvent(event, card: Card, context: TContext, additionalProperties): void {
         this.addLeavesPlayPropertiesToEvent(event, card, context, additionalProperties);
     }
 }

--- a/server/game/gameSystems/DeployLeaderSystem.ts
+++ b/server/game/gameSystems/DeployLeaderSystem.ts
@@ -7,7 +7,7 @@ import * as Contract from '../core/utils/Contract';
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IDeployLeaderProperties extends ICardTargetSystemProperties {}
 
-export class DeployLeaderSystem extends CardTargetSystem<IDeployLeaderProperties> {
+export class DeployLeaderSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IDeployLeaderProperties> {
     public override readonly name = 'deploy leader';
     public override readonly eventName = EventName.OnLeaderDeployed;
     public override readonly effectDescription = 'deploy {0}';
@@ -20,7 +20,7 @@ export class DeployLeaderSystem extends CardTargetSystem<IDeployLeaderProperties
         event.card.deploy();
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         if (!card.isLeader() || card.deployed) {
             return false;
         }

--- a/server/game/gameSystems/DeployLeaderSystem.ts
+++ b/server/game/gameSystems/DeployLeaderSystem.ts
@@ -2,7 +2,7 @@ import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
 import { CardType, EventName } from '../core/Constants';
 import { type ICardTargetSystemProperties, CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
-import Contract from '../core/utils/Contract';
+import * as Contract from '../core/utils/Contract';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IDeployLeaderProperties extends ICardTargetSystemProperties {}
@@ -15,11 +15,7 @@ export class DeployLeaderSystem extends CardTargetSystem<IDeployLeaderProperties
     protected override readonly targetTypeFilter = [CardType.Leader];
 
     public eventHandler(event): void {
-        if (
-            !Contract.assertTrue(event.card.isLeader())
-        ) {
-            return;
-        }
+        Contract.assertTrue(event.card.isLeader());
 
         event.card.deploy();
     }

--- a/server/game/gameSystems/DrawSpecificCardSystem.ts
+++ b/server/game/gameSystems/DrawSpecificCardSystem.ts
@@ -13,7 +13,7 @@ export interface IDrawSpecificCardProperties extends ICardTargetSystemProperties
     changePlayer?: boolean;
 }
 
-export class DrawSpecificCardSystem extends CardTargetSystem<IDrawSpecificCardProperties> {
+export class DrawSpecificCardSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IDrawSpecificCardProperties> {
     public override readonly name = 'drawSpecific';
     public override targetTypeFilter = [WildcardCardType.Unit, WildcardCardType.Upgrade, CardType.Event];
 
@@ -52,12 +52,12 @@ export class DrawSpecificCardSystem extends CardTargetSystem<IDrawSpecificCardPr
         }
     }
 
-    public override getCostMessage(context: AbilityContext): [string, any[]] {
+    public override getCostMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context) as IDrawSpecificCardProperties;
         return ['shuffling {0} into their deck', [properties.target]];
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context) as IDrawSpecificCardProperties;
         const destinationController = Array.isArray(properties.target)
             ? properties.changePlayer
@@ -75,7 +75,7 @@ export class DrawSpecificCardSystem extends CardTargetSystem<IDrawSpecificCardPr
         ];
     }
 
-    public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         const { changePlayer } = this.generatePropertiesFromContext(context, additionalProperties) as IDrawSpecificCardProperties;
         return (
             (!changePlayer ||

--- a/server/game/gameSystems/DrawSystem.ts
+++ b/server/game/gameSystems/DrawSystem.ts
@@ -8,7 +8,7 @@ export interface IDrawProperties extends IPlayerTargetSystemProperties {
     amount?: number
 }
 
-export class DrawSystem extends PlayerTargetSystem<IDrawProperties> {
+export class DrawSystem<TContext extends AbilityContext = AbilityContext> extends PlayerTargetSystem<TContext, IDrawProperties> {
     public override readonly name = 'draw';
     public override readonly eventName = EventName.OnCardsDrawn;
 
@@ -20,21 +20,21 @@ export class DrawSystem extends PlayerTargetSystem<IDrawProperties> {
         event.player.drawCardsToHand(event.amount);
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
         return ['draw ' + properties.amount + (properties.amount > 1 ? ' cards' : ' card'), []];
     }
 
-    public override canAffect(player: Player, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(player: Player, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.amount !== 0 && super.canAffect(player, context);
     }
 
-    public override defaultTargets(context: AbilityContext): Player[] {
+    public override defaultTargets(context: TContext): Player[] {
         return [context.player];
     }
 
-    protected override addPropertiesToEvent(event, player: Player, context: AbilityContext, additionalProperties): void {
+    protected override addPropertiesToEvent(event, player: Player, context: TContext, additionalProperties): void {
         const { amount } = this.generatePropertiesFromContext(context, additionalProperties);
         super.addPropertiesToEvent(event, player, context, additionalProperties);
         event.amount = amount;

--- a/server/game/gameSystems/ExecuteHandlerSystem.ts
+++ b/server/game/gameSystems/ExecuteHandlerSystem.ts
@@ -3,8 +3,8 @@ import { GameSystem, type IGameSystemProperties } from '../core/gameSystem/GameS
 import { Card } from '../core/card/Card';
 import { GameEvent } from '../core/event/GameEvent';
 
-export interface IExecuteHandlerSystemProperties extends IGameSystemProperties {
-    handler: (context: AbilityContext) => void;
+export interface IExecuteHandlerSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
+    handler: (context: TContext) => void;
     hasTargetsChosenByInitiatingPlayer?: boolean;
 }
 
@@ -12,7 +12,7 @@ export interface IExecuteHandlerSystemProperties extends IGameSystemProperties {
  * A {@link GameSystem} which executes a handler function
  * @override This was copied from L5R but has not been tested yet
  */
-export class ExecuteHandlerSystem extends GameSystem {
+export class ExecuteHandlerSystem<TContext extends AbilityContext = AbilityContext> extends GameSystem<TContext, IExecuteHandlerSystemProperties<TContext>> {
     protected override readonly defaultProperties: IExecuteHandlerSystemProperties = {
         handler: () => true,
         hasTargetsChosenByInitiatingPlayer: false
@@ -27,15 +27,15 @@ export class ExecuteHandlerSystem extends GameSystem {
         return true;
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         return true;
     }
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
         events.push(this.generateEvent(null, context, additionalProperties));
     }
 
-    public override hasTargetsChosenByInitiatingPlayer(context: AbilityContext, additionalProperties = {}) {
+    public override hasTargetsChosenByInitiatingPlayer(context: TContext, additionalProperties = {}) {
         const { hasTargetsChosenByInitiatingPlayer } = this.generatePropertiesFromContext(
             context,
             additionalProperties

--- a/server/game/gameSystems/ExhaustOrReadySystem.ts
+++ b/server/game/gameSystems/ExhaustOrReadySystem.ts
@@ -8,10 +8,10 @@ import { CardWithExhaustProperty } from '../core/card/CardTypes';
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IExhaustOrReadyProperties extends ICardTargetSystemProperties {}
 
-export abstract class ExhaustOrReadySystem<TProperties extends IExhaustOrReadyProperties = IExhaustOrReadyProperties> extends CardTargetSystem<TProperties> {
+export abstract class ExhaustOrReadySystem<TContext extends AbilityContext = AbilityContext, TProperties extends IExhaustOrReadyProperties = IExhaustOrReadyProperties> extends CardTargetSystem<TContext, TProperties> {
     protected override readonly targetTypeFilter = [WildcardCardType.Unit, CardType.Event, WildcardCardType.Upgrade, CardType.Leader];
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         if (
             !EnumHelpers.isArena(card.location) &&
             card.location !== Location.Resource &&

--- a/server/game/gameSystems/ExhaustSystem.ts
+++ b/server/game/gameSystems/ExhaustSystem.ts
@@ -7,7 +7,7 @@ import { ExhaustOrReadySystem, IExhaustOrReadyProperties } from './ExhaustOrRead
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IExhaustSystemProperties extends IExhaustOrReadyProperties {}
 
-export class ExhaustSystem extends ExhaustOrReadySystem<IExhaustSystemProperties> {
+export class ExhaustSystem<TContext extends AbilityContext = AbilityContext> extends ExhaustOrReadySystem<TContext, IExhaustSystemProperties> {
     public override readonly name = 'exhaust';
     public override readonly eventName = EventName.OnCardExhausted;
     public override readonly costDescription = 'exhausting {0}';
@@ -18,7 +18,7 @@ export class ExhaustSystem extends ExhaustOrReadySystem<IExhaustSystemProperties
         event.card.exhaust();
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         if (!super.canAffect(card, context)) {
             return false;
         }

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -61,6 +61,7 @@ import { SelectCardSystem, ISelectCardProperties } from './SelectCardSystem';
 import { SequentialSystem } from './SequentialSystem';
 import { ShuffleDeckSystem, IShuffleDeckProperties } from './ShuffleDeckSystem';
 import { SimultaneousGameSystem } from './SimultaneousSystem';
+import { MetaSystem } from '../core/gameSystem/MetaSystem';
 // import { TakeControlAction, TakeControlProperties } from './TakeControlAction';
 // import { TriggerAbilityAction, TriggerAbilityProperties } from './TriggerAbilityAction';
 // import { TurnCardFacedownAction, TurnCardFacedownProperties } from './TurnCardFacedownAction';
@@ -283,8 +284,8 @@ export function replacementEffect(propertyFactory: PropsFactory<IReplacementEffe
 // export function chooseAction(propertyFactory: PropsFactory<ChooseActionProperties>): GameSystem {
 //     return new ChooseGameAction(propertyFactory);
 // } // choices, activePromptTitle = 'Select one'
-export function conditional(propertyFactory: PropsFactory<IConditionalSystemProperties>): GameSystem {
-    return new ConditionalSystem(propertyFactory);
+export function conditional<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IConditionalSystemProperties<TContext>>): MetaSystem<TContext> {
+    return new ConditionalSystem<TContext>(propertyFactory);
 }
 // export function onAffinity(propertyFactory: PropsFactory<AffinityActionProperties>): GameSystem {
 //     return new AffinityAction(propertyFactory);
@@ -316,8 +317,8 @@ export function sequential(gameSystems: GameSystem[]): GameSystem {
 // export function sequentialContext(propertyFactory: PropsFactory<SequentialContextProperties>): GameSystem {
 //     return new SequentialContextAction(propertyFactory);
 // }
-export function simultaneous(gameSystems: GameSystem[], ignoreTargetingRequirements = null): GameSystem {
-    return new SimultaneousGameSystem(gameSystems, ignoreTargetingRequirements);
+export function simultaneous<TContext extends AbilityContext = AbilityContext>(gameSystems: (GameSystem | MetaSystem<TContext>)[], ignoreTargetingRequirements = null): MetaSystem<TContext> {
+    return new SimultaneousGameSystem<TContext>(gameSystems, ignoreTargetingRequirements);
 }
 
 export function shuffleDeck(propertyFactory: PropsFactory<IShuffleDeckProperties> = {}): PlayerTargetSystem {

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -62,11 +62,12 @@ import { SequentialSystem } from './SequentialSystem';
 import { ShuffleDeckSystem, IShuffleDeckProperties } from './ShuffleDeckSystem';
 import { SimultaneousGameSystem } from './SimultaneousSystem';
 import { MetaSystem } from '../core/gameSystem/MetaSystem';
+import { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
 // import { TakeControlAction, TakeControlProperties } from './TakeControlAction';
 // import { TriggerAbilityAction, TriggerAbilityProperties } from './TriggerAbilityAction';
 // import { TurnCardFacedownAction, TurnCardFacedownProperties } from './TurnCardFacedownAction';
 
-type PropsFactory<Props> = Props | ((context: AbilityContext) => Props);
+type PropsFactory<Props, TContext extends AbilityContext = AbilityContext> = Props | ((context: TContext) => Props);
 
 // allow block comments without spaces so we can have compact jsdoc descriptions in this file
 /* eslint @stylistic/js/lines-around-comment: off */
@@ -77,29 +78,29 @@ type PropsFactory<Props> = Props | ((context: AbilityContext) => Props);
 // export function addToken(propertyFactory: PropsFactory<AddTokenProperties> = {}): GameSystem {
 //     return new AddTokenAction(propertyFactory);
 // }
-export function attachUpgrade(propertyFactory: PropsFactory<IAttachUpgradeProperties> = {}): GameSystem {
-    return new AttachUpgradeSystem(propertyFactory);
+export function attachUpgrade<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IAttachUpgradeProperties, TContext> = {}): GameSystem<TContext> {
+    return new AttachUpgradeSystem<TContext>(propertyFactory);
 }
-export function attack(propertyFactory: PropsFactory<IInitiateAttackProperties> = {}): CardTargetSystem {
-    return new InitiateAttackSystem(propertyFactory);
+export function attack<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IInitiateAttackProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new InitiateAttackSystem<TContext>(propertyFactory);
 }
-export function cardLastingEffect(propertyFactory: PropsFactory<ICardLastingEffectProperties>): GameSystem {
-    return new CardLastingEffectSystem(propertyFactory);
+export function cardLastingEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICardLastingEffectProperties, TContext>): GameSystem<TContext> {
+    return new CardLastingEffectSystem<TContext>(propertyFactory);
 }
 // export function createToken(propertyFactory: PropsFactory<CreateTokenProperties> = {}): GameSystem {
 //     return new CreateTokenAction(propertyFactory);
 // }
-export function damage(propertyFactory: PropsFactory<IDamageProperties>): GameSystem {
-    return new DamageSystem(propertyFactory);
+export function damage<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IDamageProperties, TContext>): GameSystem<TContext> {
+    return new DamageSystem<TContext>(propertyFactory);
 }
 // export function detach(propertyFactory: PropsFactory<DetachActionProperties> = {}): GameSystem {
 //     return new DetachAction(propertyFactory);
 // }
-export function deploy(propertyFactory: PropsFactory<IDeployLeaderProperties> = {}): CardTargetSystem {
-    return new DeployLeaderSystem(propertyFactory);
+export function deploy<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IDeployLeaderProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new DeployLeaderSystem<TContext>(propertyFactory);
 }
-export function defeat(propertyFactory: PropsFactory<IDefeatCardProperties> = {}): CardTargetSystem {
-    return new DefeatCardSystem(propertyFactory);
+export function defeat<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IDefeatCardProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new DefeatCardSystem<TContext>(propertyFactory);
 }
 // export function discardCard(propertyFactory: PropsFactory<DiscardCardProperties> = {}): CardGameAction {
 //     return new DiscardCardAction(propertyFactory);
@@ -107,23 +108,23 @@ export function defeat(propertyFactory: PropsFactory<IDefeatCardProperties> = {}
 // export function discardFromPlay(propertyFactory: PropsFactory<DiscardFromPlayProperties> = {}): GameSystem {
 //     return new DiscardFromPlayAction(propertyFactory);
 // }
-export function exhaust(propertyFactory: PropsFactory<IExhaustSystemProperties> = {}): CardTargetSystem {
-    return new ExhaustSystem(propertyFactory);
+export function exhaust<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IExhaustSystemProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new ExhaustSystem<TContext>(propertyFactory);
 }
-export function forThisPhaseCardEffect(propertyFactory: PropsFactory<ICardPhaseLastingEffectProperties>): GameSystem {
-    return new CardPhaseLastingEffectSystem(propertyFactory);
+export function forThisPhaseCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICardPhaseLastingEffectProperties, TContext>): GameSystem<TContext> {
+    return new CardPhaseLastingEffectSystem<TContext>(propertyFactory);
 }
-export function giveExperience(propertyFactory: PropsFactory<IGiveExperienceProperties> = {}): CardTargetSystem {
-    return new GiveExperienceSystem(propertyFactory);
+export function giveExperience<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IGiveExperienceProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new GiveExperienceSystem<TContext>(propertyFactory);
 }
-export function giveShield(propertyFactory: PropsFactory<IGiveShieldProperties> = {}): CardTargetSystem {
-    return new GiveShieldSystem(propertyFactory);
+export function giveShield<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IGiveShieldProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new GiveShieldSystem<TContext>(propertyFactory);
 }
-export function heal(propertyFactory: PropsFactory<IHealProperties>): GameSystem {
-    return new HealSystem(propertyFactory);
+export function heal<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IHealProperties, TContext>): GameSystem<TContext> {
+    return new HealSystem<TContext>(propertyFactory);
 }
-export function lookAt(propertyFactory: PropsFactory<ILookAtProperties> = {}): GameSystem {
-    return new LookAtSystem(propertyFactory);
+export function lookAt<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ILookAtProperties, TContext> = {}): GameSystem<TContext> {
+    return new LookAtSystem<TContext>(propertyFactory);
 }
 
 /**
@@ -131,8 +132,8 @@ export function lookAt(propertyFactory: PropsFactory<ILookAtProperties> = {}): G
  * default shuffle = false
  * default faceup = false
  */
-export function moveCard(propertyFactory: PropsFactory<IMoveCardProperties>): CardTargetSystem {
-    return new MoveCardSystem(propertyFactory);
+export function moveCard<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IMoveCardProperties, TContext>): CardTargetSystem<TContext> {
+    return new MoveCardSystem<TContext>(propertyFactory);
 }
 // /**
 //  * default resetOnCancel = false
@@ -140,14 +141,14 @@ export function moveCard(propertyFactory: PropsFactory<IMoveCardProperties>): Ca
 // export function playCard(propertyFactory: PropsFactory<PlayCardProperties> = {}): GameSystem {
 //     return new PlayCardAction(propertyFactory);
 // }
-export function payResourceCost(propertyFactory: PropsFactory<IPayResourceCostProperties>): GameSystem {
-    return new PayResourceCostSystem(propertyFactory);
+export function payResourceCost<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IPayResourceCostProperties, TContext>): GameSystem<TContext> {
+    return new PayResourceCostSystem<TContext>(propertyFactory);
 }
 /**
  * default status = ordinary
  */
-export function putIntoPlay(propertyFactory: PropsFactory<IPutIntoPlayProperties> = {}): GameSystem {
-    return new PutIntoPlaySystem(propertyFactory);
+export function putIntoPlay<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IPutIntoPlayProperties, TContext> = {}): GameSystem<TContext> {
+    return new PutIntoPlaySystem<TContext>(propertyFactory);
 }
 // /**
 //  * default status = ordinary
@@ -155,8 +156,8 @@ export function putIntoPlay(propertyFactory: PropsFactory<IPutIntoPlayProperties
 // export function opponentPutIntoPlay(propertyFactory: PropsFactory<OpponentPutIntoPlayProperties> = {}): GameSystem {
 //     return new OpponentPutIntoPlayAction(propertyFactory, false);
 // }
-export function ready(propertyFactory: PropsFactory<IReadySystemProperties> = {}): GameSystem {
-    return new ReadySystem(propertyFactory);
+export function ready<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IReadySystemProperties, TContext> = {}): GameSystem<TContext> {
+    return new ReadySystem<TContext>(propertyFactory);
 }
 // export function removeFromGame(propertyFactory: PropsFactory<RemoveFromGameProperties> = {}): CardGameAction {
 //     return new RemoveFromGameAction(propertyFactory);
@@ -170,17 +171,17 @@ export function ready(propertyFactory: PropsFactory<IReadySystemProperties> = {}
 // export function returnToDeck(propertyFactory: PropsFactory<ReturnToDeckProperties> = {}): CardGameAction {
 //     return new ReturnToDeckAction(propertyFactory);
 // }
-export function returnToHand(propertyFactory: PropsFactory<IReturnToHandProperties> = {}): CardTargetSystem {
-    return new ReturnToHandSystem(propertyFactory);
+export function returnToHand<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IReturnToHandProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new ReturnToHandSystem<TContext>(propertyFactory);
 }
-export function returnToHandFromPlay(propertyFactory: PropsFactory<IReturnToHandFromPlayProperties> = {}): CardTargetSystem {
-    return new ReturnToHandFromPlaySystem(propertyFactory);
+export function returnToHandFromPlay<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IReturnToHandFromPlayProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new ReturnToHandFromPlaySystem<TContext>(propertyFactory);
 }
 /**
  * default chatMessage = false
  */
-export function reveal(propertyFactory: PropsFactory<IRevealProperties> = {}): CardTargetSystem {
-    return new RevealSystem(propertyFactory);
+export function reveal<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IRevealProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new RevealSystem<TContext>(propertyFactory);
 }
 // export function sacrifice(propertyFactory: PropsFactory<DiscardFromPlayProperties> = {}): CardGameAction {
 //     return new DiscardFromPlayAction(propertyFactory, true);
@@ -229,8 +230,8 @@ export function reveal(propertyFactory: PropsFactory<IRevealProperties> = {}): C
  * default placeOnBottomInRandomOrder = true (place unchosen cards on the bottom of the deck in random order)
  * default cardCondition = always true
  */
-export function deckSearch(propertyFactory: PropsFactory<ISearchDeckProperties>): GameSystem {
-    return new SearchDeckSystem(propertyFactory);
+export function deckSearch<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISearchDeckProperties<TContext>, TContext>): GameSystem<TContext> {
+    return new SearchDeckSystem<TContext>(propertyFactory);
 }
 
 /**
@@ -248,15 +249,15 @@ export function deckSearch(propertyFactory: PropsFactory<ISearchDeckProperties>)
 /**
  * default amount = 1
  */
-export function draw(propertyFactory: PropsFactory<IDrawProperties> = {}): GameSystem {
-    return new DrawSystem(propertyFactory);
+export function draw<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IDrawProperties, TContext> = {}): GameSystem<TContext> {
+    return new DrawSystem<TContext>(propertyFactory);
 }
 
 /**
  * default amount = 1
  */
-export function drawSpecificCard(propertyFactory: PropsFactory<IDrawSpecificCardProperties> = {}): CardTargetSystem {
-    return new DrawSpecificCardSystem(propertyFactory);
+export function drawSpecificCard<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IDrawSpecificCardProperties, TContext> = {}): CardTargetSystem<TContext> {
+    return new DrawSpecificCardSystem<TContext>(propertyFactory);
 }
 // export function playerLastingEffect(propertyFactory: PropsFactory<LastingEffectProperties>): GameSystem {
 //     return new LastingEffectAction(propertyFactory);
@@ -265,14 +266,14 @@ export function drawSpecificCard(propertyFactory: PropsFactory<IDrawSpecificCard
 // //////////////
 // // GENERIC
 // //////////////
-export function handler(propertyFactory: PropsFactory<IExecuteHandlerSystemProperties>): GameSystem {
-    return new ExecuteHandlerSystem(propertyFactory);
+export function handler<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IExecuteHandlerSystemProperties, TContext>): GameSystem<TContext> {
+    return new ExecuteHandlerSystem<TContext>(propertyFactory);
 }
-export function noAction(propertyFactory: PropsFactory<INoActionSystemProperties> = {}): GameSystem {
-    return new NoActionSystem(propertyFactory);
+export function noAction<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<INoActionSystemProperties, TContext> = {}): GameSystem<TContext> {
+    return new NoActionSystem<TContext>(propertyFactory);
 }
-export function replacementEffect(propertyFactory: PropsFactory<IReplacementEffectSystemProperties>): GameSystem {
-    return new ReplacementEffectSystem(propertyFactory);
+export function replacementEffect<TContext extends TriggeredAbilityContext = TriggeredAbilityContext>(propertyFactory: PropsFactory<IReplacementEffectSystemProperties, TContext>): GameSystem<TContext> {
+    return new ReplacementEffectSystem<TContext>(propertyFactory);
 }
 
 // //////////////
@@ -284,7 +285,7 @@ export function replacementEffect(propertyFactory: PropsFactory<IReplacementEffe
 // export function chooseAction(propertyFactory: PropsFactory<ChooseActionProperties>): GameSystem {
 //     return new ChooseGameAction(propertyFactory);
 // } // choices, activePromptTitle = 'Select one'
-export function conditional<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IConditionalSystemProperties<TContext>>): MetaSystem<TContext> {
+export function conditional<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IConditionalSystemProperties<TContext>, TContext>): GameSystem<TContext> {
     return new ConditionalSystem<TContext>(propertyFactory);
 }
 // export function onAffinity(propertyFactory: PropsFactory<AffinityActionProperties>): GameSystem {
@@ -305,22 +306,22 @@ export function conditional<TContext extends AbilityContext = AbilityContext>(pr
 // export function menuPrompt(propertyFactory: PropsFactory<MenuPromptProperties>): GameSystem {
 //     return new MenuPromptAction(propertyFactory);
 // }
-export function selectCard(propertyFactory: PropsFactory<ISelectCardProperties>): GameSystem {
-    return new SelectCardSystem(propertyFactory);
+export function selectCard<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISelectCardProperties<TContext>, TContext>): GameSystem<TContext> {
+    return new SelectCardSystem<TContext>(propertyFactory);
 }
 // export function selectToken(propertyFactory: PropsFactory<SelectTokenProperties>): GameSystem {
 //     return new SelectTokenAction(propertyFactory);
 // }
-export function sequential(gameSystems: GameSystem[]): GameSystem {
-    return new SequentialSystem(gameSystems);
+export function sequential<TContext extends AbilityContext = AbilityContext>(gameSystems: GameSystem<TContext>[]): GameSystem<TContext> {
+    return new SequentialSystem<TContext>(gameSystems);
 } // takes an array of gameActions, not a propertyFactory
 // export function sequentialContext(propertyFactory: PropsFactory<SequentialContextProperties>): GameSystem {
 //     return new SequentialContextAction(propertyFactory);
 // }
-export function simultaneous<TContext extends AbilityContext = AbilityContext>(gameSystems: (GameSystem | MetaSystem<TContext>)[], ignoreTargetingRequirements = null): MetaSystem<TContext> {
+export function simultaneous<TContext extends AbilityContext = AbilityContext>(gameSystems: (GameSystem<TContext>)[], ignoreTargetingRequirements = null): GameSystem<TContext> {
     return new SimultaneousGameSystem<TContext>(gameSystems, ignoreTargetingRequirements);
 }
 
-export function shuffleDeck(propertyFactory: PropsFactory<IShuffleDeckProperties> = {}): PlayerTargetSystem {
-    return new ShuffleDeckSystem(propertyFactory);
+export function shuffleDeck<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IShuffleDeckProperties, TContext> = {}): PlayerTargetSystem<TContext> {
+    return new ShuffleDeckSystem<TContext>(propertyFactory);
 }

--- a/server/game/gameSystems/GiveExperienceSystem.ts
+++ b/server/game/gameSystems/GiveExperienceSystem.ts
@@ -5,7 +5,7 @@ import { GiveTokenUpgradeSystem, IGiveTokenUpgradeProperties } from './GiveToken
 
 export type IGiveExperienceProperties = Omit<IGiveTokenUpgradeProperties, 'tokenType'>;
 
-export class GiveExperienceSystem extends GiveTokenUpgradeSystem {
+export class GiveExperienceSystem<TContext extends AbilityContext = AbilityContext> extends GiveTokenUpgradeSystem<TContext> {
     public override readonly name = 'give experience';
     protected override readonly defaultProperties: IGiveTokenUpgradeProperties = {
         amount: 1,

--- a/server/game/gameSystems/GiveShieldSystem.ts
+++ b/server/game/gameSystems/GiveShieldSystem.ts
@@ -5,7 +5,7 @@ import { GiveTokenUpgradeSystem, IGiveTokenUpgradeProperties } from './GiveToken
 
 export type IGiveShieldProperties = Omit<IGiveTokenUpgradeProperties, 'tokenType'>;
 
-export class GiveShieldSystem extends GiveTokenUpgradeSystem {
+export class GiveShieldSystem<TContext extends AbilityContext = AbilityContext> extends GiveTokenUpgradeSystem<TContext> {
     public override readonly name = 'give shield';
     protected override readonly defaultProperties: IGiveTokenUpgradeProperties = {
         amount: 1,

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -3,7 +3,7 @@ import { Card } from '../core/card/Card';
 import { CardTypeFilter, EventName, TokenName, WildcardCardType } from '../core/Constants';
 import { CardTargetSystem, ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import { IGameSystemProperties } from '../core/gameSystem/GameSystem';
-import Contract from '../core/utils/Contract';
+import * as Contract from '../core/utils/Contract';
 import * as EnumHelpers from '../core/utils/EnumHelpers';
 
 export interface IGiveTokenUpgradeProperties extends ICardTargetSystemProperties {
@@ -20,12 +20,8 @@ export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveToken
         const cardReceivingTokenUpgrade = event.card;
         const properties = this.generatePropertiesFromContext(event.context);
 
-        if (
-            !Contract.assertTrue(cardReceivingTokenUpgrade.isUnit()) ||
-            !Contract.assertTrue(EnumHelpers.isArena(cardReceivingTokenUpgrade.location))
-        ) {
-            return;
-        }
+        Contract.assertTrue(cardReceivingTokenUpgrade.isUnit());
+        Contract.assertTrue(EnumHelpers.isArena(cardReceivingTokenUpgrade.location));
 
         for (let i = 0; i < properties.amount; i++) {
             const tokenUpgrade = event.context.game.generateToken(event.context.source.controller, properties.tokenType);
@@ -45,13 +41,9 @@ export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveToken
     public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context);
 
-        if (
-            !Contract.assertNotNullLike(context) ||
-            !Contract.assertNotNullLike(context.player) ||
-            !Contract.assertNotNullLike(card)
-        ) {
-            return false;
-        }
+        Contract.assertNotNullLike(context);
+        Contract.assertNotNullLike(context.player);
+        Contract.assertNotNullLike(card);
 
         if (
             !card.isUnit() ||

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -12,7 +12,7 @@ export interface IGiveTokenUpgradeProperties extends ICardTargetSystemProperties
 }
 
 /** Base class for managing the logic for giving token upgrades to cards (currently shield and experience) */
-export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveTokenUpgradeProperties> {
+export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IGiveTokenUpgradeProperties> {
     public override readonly eventName = EventName.OnUpgradeAttached;
     protected override readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Unit];
 
@@ -29,7 +29,7 @@ export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveToken
         }
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
 
         if (properties.amount === 1) {
@@ -38,7 +38,7 @@ export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveToken
         return ['attach {0} {1}s to {2}', [properties.amount, properties.tokenType, properties.target]];
     }
 
-    public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context);
 
         Contract.assertNotNullLike(context);
@@ -60,7 +60,7 @@ export abstract class GiveTokenUpgradeSystem extends CardTargetSystem<IGiveToken
         return this.canAffect(event.card, event.context, additionalProperties);
     }
 
-    protected override addPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+    protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties): void {
         event.name = this.eventName;
         event.card = card;
         event.context = context;

--- a/server/game/gameSystems/HealSystem.ts
+++ b/server/game/gameSystems/HealSystem.ts
@@ -3,7 +3,7 @@ import type { Card } from '../core/card/Card';
 import { AbilityRestriction, CardType, EventName, WildcardCardType } from '../core/Constants';
 import * as EnumHelpers from '../core/utils/EnumHelpers';
 import { type ICardTargetSystemProperties, CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
-import Contract from '../core/utils/Contract';
+import * as Contract from '../core/utils/Contract';
 import * as CardHelpers from '../core/card/CardHelpers';
 import { CardWithDamageProperty } from '../core/card/CardTypes';
 

--- a/server/game/gameSystems/HealSystem.ts
+++ b/server/game/gameSystems/HealSystem.ts
@@ -34,7 +34,7 @@ export class HealSystem extends CardTargetSystem<IHealProperties> {
         if (!EnumHelpers.isAttackableLocation(card.location)) {
             return false;
         }
-        if (properties.isCost && (properties.amount === 0 || (card as CardWithDamageProperty).damage === 0)) {
+        if (properties.isCost && (properties.amount === 0 || card.damage === 0)) {
             return false;
         }
         if (card.hasRestriction(AbilityRestriction.BeHealed, context)) {

--- a/server/game/gameSystems/HealSystem.ts
+++ b/server/game/gameSystems/HealSystem.ts
@@ -11,7 +11,7 @@ export interface IHealProperties extends ICardTargetSystemProperties {
     amount: number;
 }
 
-export class HealSystem extends CardTargetSystem<IHealProperties> {
+export class HealSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IHealProperties> {
     public override readonly name = 'heal';
     public override readonly eventName = EventName.OnDamageRemoved;
     protected override readonly targetTypeFilter = [WildcardCardType.Unit, CardType.Base];
@@ -20,13 +20,13 @@ export class HealSystem extends CardTargetSystem<IHealProperties> {
         event.card.removeDamage(event.healAmount);
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const { amount, target } = this.generatePropertiesFromContext(context);
 
         return ['heal {1} damage from {0}', [amount, target]];
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         const properties = this.generatePropertiesFromContext(context);
         if (!card.canBeDamaged()) {
             return false;
@@ -43,7 +43,7 @@ export class HealSystem extends CardTargetSystem<IHealProperties> {
         return super.canAffect(card, context);
     }
 
-    protected override addPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+    protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties): void {
         const { amount } = this.generatePropertiesFromContext(context, additionalProperties);
         super.addPropertiesToEvent(event, card, context, additionalProperties);
         event.healAmount = amount;

--- a/server/game/gameSystems/InitiateAttackSystem.ts
+++ b/server/game/gameSystems/InitiateAttackSystem.ts
@@ -9,9 +9,9 @@ import * as Contract from '../core/utils/Contract';
 import { IAttackProperties } from './AttackStepsSystem';
 import * as GameSystemLibrary from './GameSystemLibrary';
 
-export interface IInitiateAttackProperties extends IAttackProperties {
+export interface IInitiateAttackProperties<TContext extends AbilityContext = AbilityContext> extends IAttackProperties {
     ignoredRequirements?: string[];
-    attackerCondition?: (card: Card, context: AbilityContext) => boolean;
+    attackerCondition?: (card: Card, context: TContext) => boolean;
 }
 
 /**
@@ -19,7 +19,7 @@ export interface IInitiateAttackProperties extends IAttackProperties {
  * The `target` property is the unit that will be attacking. The system resolves the {@link InitiateAttackAction}
  * ability for the passed unit, which will trigger resolution of the attack target.
  */
-export class InitiateAttackSystem extends CardTargetSystem<IInitiateAttackProperties> {
+export class InitiateAttackSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IInitiateAttackProperties<TContext>> {
     public override readonly name = 'initiateUnitAttack';
     protected override readonly defaultProperties: IInitiateAttackProperties = {
         ignoredRequirements: [],
@@ -32,12 +32,12 @@ export class InitiateAttackSystem extends CardTargetSystem<IInitiateAttackProper
         event.context.game.queueStep(new AbilityResolver(event.context.game, newContext, true));
     }
 
-    public override getEffectMessage(context: TriggeredAbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
         return ['initiate attack with {0}', [properties.target]];
     }
 
-    protected override addPropertiesToEvent(event, attacker, context: AbilityContext, additionalProperties = {}): void {
+    protected override addPropertiesToEvent(event, attacker, context: TContext, additionalProperties = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         Contract.assertTrue(attacker.isUnit());
 
@@ -46,7 +46,7 @@ export class InitiateAttackSystem extends CardTargetSystem<IInitiateAttackProper
         event.attackAbility = this.generateAttackAbilityNoTarget(attacker, properties);
     }
 
-    public override canAffect(card: Card, context: TriggeredAbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         if (
             !card.isUnit() ||

--- a/server/game/gameSystems/InitiateAttackSystem.ts
+++ b/server/game/gameSystems/InitiateAttackSystem.ts
@@ -5,7 +5,7 @@ import { CardTargetSystem, ICardTargetSystemProperties } from '../core/gameSyste
 import { UnitCard } from '../core/card/CardTypes';
 import { InitiateAttackAction } from '../actions/InitiateAttackAction';
 import { AbilityContext } from '../core/ability/AbilityContext';
-import Contract from '../core/utils/Contract';
+import * as Contract from '../core/utils/Contract';
 import { IAttackProperties } from './AttackStepsSystem';
 import * as GameSystemLibrary from './GameSystemLibrary';
 
@@ -39,9 +39,7 @@ export class InitiateAttackSystem extends CardTargetSystem<IInitiateAttackProper
 
     protected override addPropertiesToEvent(event, attacker, context: AbilityContext, additionalProperties = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        if (!Contract.assertTrue(attacker.isUnit())) {
-            return;
-        }
+        Contract.assertTrue(attacker.isUnit());
 
         super.addPropertiesToEvent(event, attacker, context, additionalProperties);
 

--- a/server/game/gameSystems/LookAtSystem.ts
+++ b/server/game/gameSystems/LookAtSystem.ts
@@ -5,7 +5,7 @@ import { ViewCardSystem, IViewCardProperties, ViewCardMode } from './ViewCardSys
 
 export type ILookAtProperties = Omit<IViewCardProperties, 'viewType'>;
 
-export class LookAtSystem extends ViewCardSystem {
+export class LookAtSystem<TContext extends AbilityContext = AbilityContext> extends ViewCardSystem<TContext> {
     public override readonly name = 'lookAt';
     public override readonly eventName = EventName.OnLookAtCard;
     public override readonly effectDescription = 'look at a card';
@@ -22,7 +22,7 @@ export class LookAtSystem extends ViewCardSystem {
         super(propsWithViewType);
     }
 
-    public override getMessageArgs(event: any, context: AbilityContext, additionalProperties: any): any[] {
+    public override getMessageArgs(event: any, context: TContext, additionalProperties: any): any[] {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const messageArgs = properties.messageArgs ? properties.messageArgs(event.cards) : [
             context.source, event.cards

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -16,7 +16,7 @@ export interface IMoveCardProperties extends ICardTargetSystemProperties {
     discardDestinationCards?: boolean;
 }
 
-export class MoveCardSystem extends CardTargetSystem<IMoveCardProperties> {
+export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IMoveCardProperties> {
     public override readonly name = 'move';
     public override targetTypeFilter = [WildcardCardType.Unit, WildcardCardType.Upgrade, CardType.Event];
 
@@ -63,12 +63,12 @@ export class MoveCardSystem extends CardTargetSystem<IMoveCardProperties> {
         // }
     }
 
-    public override getCostMessage(context: AbilityContext): [string, any[]] {
+    public override getCostMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context) as IMoveCardProperties;
         return ['shuffling {0} into their deck', [properties.target]];
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context) as IMoveCardProperties;
         const destinationController = Array.isArray(properties.target)
             ? properties.changePlayer
@@ -86,7 +86,7 @@ export class MoveCardSystem extends CardTargetSystem<IMoveCardProperties> {
         ];
     }
 
-    public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         const { changePlayer, destination } = this.generatePropertiesFromContext(context, additionalProperties) as IMoveCardProperties;
         return (
             (!changePlayer ||

--- a/server/game/gameSystems/NoActionSystem.ts
+++ b/server/game/gameSystems/NoActionSystem.ts
@@ -11,7 +11,7 @@ export interface INoActionSystemProperties extends IGameSystemProperties {
  * A {@link GameSystem} which executes a handler function
  * @override This was copied from L5R but has not been tested yet
  */
-export class NoActionSystem extends GameSystem<INoActionSystemProperties> {
+export class NoActionSystem<TContext extends AbilityContext = AbilityContext> extends GameSystem<TContext, INoActionSystemProperties> {
     protected override readonly defaultProperties: INoActionSystemProperties = {
         hasLegalTarget: false
     };
@@ -24,7 +24,7 @@ export class NoActionSystem extends GameSystem<INoActionSystemProperties> {
         return allowTargetSelection;
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         const { hasLegalTarget: allowTargetSelection } = this.generatePropertiesFromContext(context);
         return allowTargetSelection;
     }

--- a/server/game/gameSystems/PayResourceCostSystem.ts
+++ b/server/game/gameSystems/PayResourceCostSystem.ts
@@ -7,7 +7,7 @@ export interface IPayResourceCostProperties extends IPlayerTargetSystemPropertie
     amount: number;
 }
 
-export class PayResourceCostSystem extends PlayerTargetSystem<IPayResourceCostProperties> {
+export class PayResourceCostSystem<TContext extends AbilityContext = AbilityContext> extends PlayerTargetSystem<TContext, IPayResourceCostProperties> {
     public override readonly name = 'payResourceCost';
     public override readonly eventName = EventName.OnSpendResources;
 
@@ -15,7 +15,7 @@ export class PayResourceCostSystem extends PlayerTargetSystem<IPayResourceCostPr
         event.player.exhaustResources(event.amount);
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
 
         if (properties.amount === 1) {
@@ -25,7 +25,7 @@ export class PayResourceCostSystem extends PlayerTargetSystem<IPayResourceCostPr
         return ['make {0} pay {1} resources', [properties.target, properties.amount]];
     }
 
-    public override getCostMessage(context: AbilityContext): [string, any[]] {
+    public override getCostMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
 
         if (properties.amount === 1) {
@@ -35,12 +35,12 @@ export class PayResourceCostSystem extends PlayerTargetSystem<IPayResourceCostPr
         return ['spending {1} resources', [properties.amount]];
     }
 
-    public override canAffect(player: Player, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(player: Player, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.amount > 0 && player.countSpendableResources() > 0 && super.canAffect(player, context, additionalProperties);
     }
 
-    protected override addPropertiesToEvent(event, player: Player, context: AbilityContext, additionalProperties): void {
+    protected override addPropertiesToEvent(event, player: Player, context: TContext, additionalProperties): void {
         const { amount } = this.generatePropertiesFromContext(context, additionalProperties);
         super.addPropertiesToEvent(event, player, context, additionalProperties);
         event.amount = amount;

--- a/server/game/gameSystems/PutIntoPlaySystem.ts
+++ b/server/game/gameSystems/PutIntoPlaySystem.ts
@@ -9,7 +9,7 @@ export interface IPutIntoPlayProperties extends ICardTargetSystemProperties {
     overrideLocation?: Location;
 }
 
-export class PutIntoPlaySystem extends CardTargetSystem<IPutIntoPlayProperties> {
+export class PutIntoPlaySystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IPutIntoPlayProperties> {
     public override readonly name = 'putIntoPlay';
     public override readonly eventName = EventName.OnUnitEntersPlay;
     public override readonly costDescription = 'putting {0} into play';
@@ -46,12 +46,12 @@ export class PutIntoPlaySystem extends CardTargetSystem<IPutIntoPlayProperties> 
         }
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const { target } = this.generatePropertiesFromContext(context);
         return ['put {0} into play', [target]];
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         const contextCopy = context.copy({ source: card });
         const player = this.getPutIntoPlayPlayer(contextCopy);
 
@@ -68,7 +68,7 @@ export class PutIntoPlaySystem extends CardTargetSystem<IPutIntoPlayProperties> 
         return true;
     }
 
-    protected override addPropertiesToEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+    protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties): void {
         const { controller, overrideLocation } = this.generatePropertiesFromContext(
             context,
             additionalProperties

--- a/server/game/gameSystems/ReadySystem.ts
+++ b/server/game/gameSystems/ReadySystem.ts
@@ -8,7 +8,7 @@ export interface IReadySystemProperties extends IExhaustOrReadyProperties {
     isRegroupPhaseReadyStep?: boolean;
 }
 
-export class ReadySystem extends ExhaustOrReadySystem<IReadySystemProperties> {
+export class ReadySystem<TContext extends AbilityContext = AbilityContext> extends ExhaustOrReadySystem<TContext, IReadySystemProperties> {
     public override readonly name = 'ready';
     public override readonly eventName = EventName.OnCardReadied;
     public override readonly costDescription = 'readying {0}';
@@ -21,7 +21,7 @@ export class ReadySystem extends ExhaustOrReadySystem<IReadySystemProperties> {
         event.card.ready();
     }
 
-    public override canAffect(card: Card, context: AbilityContext): boolean {
+    public override canAffect(card: Card, context: TContext): boolean {
         if (!super.canAffect(card, context)) {
             return false;
         }

--- a/server/game/gameSystems/ReplacementEffectSystem.ts
+++ b/server/game/gameSystems/ReplacementEffectSystem.ts
@@ -1,3 +1,4 @@
+import { AbilityContext } from '../core/ability/AbilityContext';
 import { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
 import { GameEvent } from '../core/event/GameEvent';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
@@ -12,7 +13,7 @@ export interface IReplacementEffectSystemProperties extends IGameSystemPropertie
 
 // UP NEXT: convert this into a subclass of TriggeredAbilitySystem as TriggeredReplacementEffectSystem
 
-export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystemProperties> {
+export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = TriggeredAbilityContext> extends GameSystem<TContext, IReplacementEffectSystemProperties> {
     public override eventHandler(event, additionalProperties = {}): void {
         const { replacementImmediateEffect: replacementGameAction } = this.generatePropertiesFromContext(event.context, additionalProperties);
 
@@ -37,7 +38,7 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
         event.context.cancel();
     }
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: TriggeredAbilityContext, additionalProperties = {}) {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}) {
         const event = this.createEvent(null, context, additionalProperties);
 
         super.addPropertiesToEvent(event, null, context, additionalProperties);
@@ -46,7 +47,7 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
         events.push(event);
     }
 
-    public override getEffectMessage(context: TriggeredAbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const { replacementImmediateEffect, effect } = this.generatePropertiesFromContext(context);
         if (effect) {
             return [effect, []];
@@ -57,7 +58,7 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
         return ['cancel the effects of {0}', [context.event.card]];
     }
 
-    public override generatePropertiesFromContext(context: TriggeredAbilityContext, additionalProperties = {}): IReplacementEffectSystemProperties {
+    public override generatePropertiesFromContext(context: TContext, additionalProperties = {}): IReplacementEffectSystemProperties {
         const properties = super.generatePropertiesFromContext(context, additionalProperties) as IReplacementEffectSystemProperties;
         if (properties.replacementImmediateEffect) {
             properties.replacementImmediateEffect.setDefaultTargetFn(() => properties.target);
@@ -65,7 +66,7 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
         return properties;
     }
 
-    public override hasLegalTarget(context: TriggeredAbilityContext, additionalProperties = {}): boolean {
+    public override hasLegalTarget(context: TContext, additionalProperties = {}): boolean {
         Contract.assertNotNullLike(context.event);
 
         if (context.event.cancelled) {
@@ -79,7 +80,7 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
         );
     }
 
-    public override canAffect(target: any, context: TriggeredAbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(target: any, context: TContext, additionalProperties = {}): boolean {
         const { replacementImmediateEffect: replacementGameAction } = this.generatePropertiesFromContext(context, additionalProperties);
         return (
             (!context.event.cannotBeCancelled && !replacementGameAction) ||
@@ -87,11 +88,11 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
         );
     }
 
-    public override defaultTargets(context: TriggeredAbilityContext): any[] {
+    public override defaultTargets(context: TContext): any[] {
         return context.event.card ? [context.event.card] : [];
     }
 
-    public override hasTargetsChosenByInitiatingPlayer(context: TriggeredAbilityContext, additionalProperties = {}): boolean {
+    public override hasTargetsChosenByInitiatingPlayer(context: TContext, additionalProperties = {}): boolean {
         const { replacementImmediateEffect: replacementGameAction } = this.generatePropertiesFromContext(context);
         return (
             replacementGameAction &&

--- a/server/game/gameSystems/ReplacementEffectSystem.ts
+++ b/server/game/gameSystems/ReplacementEffectSystem.ts
@@ -1,7 +1,7 @@
 import { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
 import { GameEvent } from '../core/event/GameEvent';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
-import Contract from '../core/utils/Contract';
+import * as Contract from '../core/utils/Contract';
 
 export interface IReplacementEffectSystemProperties extends IGameSystemProperties {
     effect?: string;
@@ -66,9 +66,7 @@ export class ReplacementEffectSystem extends GameSystem<IReplacementEffectSystem
     }
 
     public override hasLegalTarget(context: TriggeredAbilityContext, additionalProperties = {}): boolean {
-        if (!Contract.assertNotNullLike(context.event)) {
-            return false;
-        }
+        Contract.assertNotNullLike(context.event);
 
         if (context.event.cancelled) {
             return false;

--- a/server/game/gameSystems/ReturnToHandFromPlaySystem.ts
+++ b/server/game/gameSystems/ReturnToHandFromPlaySystem.ts
@@ -1,3 +1,4 @@
+import { AbilityContext } from '../core/ability/AbilityContext';
 import { CardType, WildcardCardType, WildcardLocation } from '../core/Constants';
 import { ReturnToHandSystem, IReturnToHandProperties } from './ReturnToHandSystem';
 
@@ -7,7 +8,7 @@ export interface IReturnToHandFromPlayProperties extends IReturnToHandProperties
 /**
  * Subclass of {@link ReturnToHandSystem} with specific configuration for returning to hand from play area only
  */
-export class ReturnToHandFromPlaySystem extends ReturnToHandSystem {
+export class ReturnToHandFromPlaySystem<TContext extends AbilityContext = AbilityContext> extends ReturnToHandSystem<TContext> {
     protected override readonly targetTypeFilter = [WildcardCardType.Unit, WildcardCardType.Upgrade];
     protected override readonly defaultProperties: IReturnToHandFromPlayProperties = {
         locationFilter: WildcardLocation.AnyArena

--- a/server/game/gameSystems/ReturnToHandSystem.ts
+++ b/server/game/gameSystems/ReturnToHandSystem.ts
@@ -15,7 +15,7 @@ export interface IReturnToHandProperties extends ICardTargetSystemProperties {
  * Configurable class for a return to hand from X zone effect. For return to hand from play area specifically,
  * see {@link ReturnToHandFromPlaySystem}
  */
-export class ReturnToHandSystem extends CardTargetSystem<IReturnToHandProperties> {
+export class ReturnToHandSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IReturnToHandProperties> {
     public override readonly name = 'returnToHand';
     public override readonly eventName = EventName.OnCardReturnedToHand;
     public override readonly effectDescription = 'return {0} to their hand';
@@ -29,12 +29,12 @@ export class ReturnToHandSystem extends CardTargetSystem<IReturnToHandProperties
         this.leavesPlayEventHandler(event, additionalProperties);
     }
 
-    public override canAffect(card: Card, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = super.generatePropertiesFromContext(context);
         return EnumHelpers.cardLocationMatches(card.location, properties.locationFilter) && super.canAffect(card, context, additionalProperties);
     }
 
-    protected override updateEvent(event, card: Card, context: AbilityContext, additionalProperties): void {
+    protected override updateEvent(event, card: Card, context: TContext, additionalProperties): void {
         this.addLeavesPlayPropertiesToEvent(event, card, context, additionalProperties);
         event.destination = Location.Hand;
     }

--- a/server/game/gameSystems/RevealSystem.ts
+++ b/server/game/gameSystems/RevealSystem.ts
@@ -7,7 +7,7 @@ import { IViewCardProperties, ViewCardMode, ViewCardSystem } from './ViewCardSys
 
 export type IRevealProperties = Omit<IViewCardProperties, 'viewType'>;
 
-export class RevealSystem extends ViewCardSystem {
+export class RevealSystem<TContext extends AbilityContext = AbilityContext> extends ViewCardSystem<TContext> {
     public override readonly name = 'reveal';
     public override readonly eventName = EventName.OnCardRevealed;
     public override readonly costDescription = 'revealing {0}';
@@ -25,14 +25,14 @@ export class RevealSystem extends ViewCardSystem {
         super(propsWithViewType);
     }
 
-    public override canAffect(card: BaseCard, context: AbilityContext): boolean {
+    public override canAffect(card: BaseCard, context: TContext): boolean {
         if (card.location === Location.Deck || card.location === Location.Hand || card.location === Location.Resource) {
             return super.canAffect(card, context);
         }
         return false;
     }
 
-    public override getMessageArgs(event: any, context: AbilityContext, additionalProperties: any): any[] {
+    public override getMessageArgs(event: any, context: TContext, additionalProperties: any): any[] {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const messageArgs = properties.messageArgs ? properties.messageArgs(event.cards) : [
             properties.player || event.context.player,

--- a/server/game/gameSystems/SearchDeckSystem.ts
+++ b/server/game/gameSystems/SearchDeckSystem.ts
@@ -12,35 +12,35 @@ import Player from '../core/Player.js';
 import { shuffleArray } from '../core/utils/Helpers.js';
 import * as Contract from '../core/utils/Contract.js';
 
-type Derivable<T> = T | ((context: AbilityContext) => T);
+type Derivable<T, TContext extends AbilityContext = AbilityContext> = T | ((context: TContext) => T);
 
-export interface ISearchDeckProperties extends IPlayerTargetSystemProperties {
+export interface ISearchDeckProperties<TContext extends AbilityContext = AbilityContext> extends IPlayerTargetSystemProperties {
     targetMode?: TargetMode.UpTo | TargetMode.Single | TargetMode.UpToVariable | TargetMode.Unlimited | TargetMode.Exactly | TargetMode.ExactlyVariable;
     activePromptTitle?: string;
     /** The number of cards from the top of the deck to search, or a function to determine how many cards to search. Default is -1, which indicates the whole deck. */
-    searchCount?: number | ((context: AbilityContext) => number);
+    searchCount?: number | ((context: TContext) => number);
     /** The number of cards to select from the search, or a function to determine how many cards to select. Default is 1. The targetMode will interact with this to determine the min/max number of cards to retrieve. */
-    selectCount?: number | ((context: AbilityContext) => number);
+    selectCount?: number | ((context: TContext) => number);
     revealSelected?: boolean;
-    shuffleWhenDone?: boolean | ((context: AbilityContext) => boolean);
+    shuffleWhenDone?: boolean | ((context: TContext) => boolean);
     title?: string;
     /** This determines what to do with the selected cards (if a custom selectedCardsHandler is not provided). */
-    selectedCardsImmediateEffect?: GameSystem<IGameSystemProperties>;
+    selectedCardsImmediateEffect?: GameSystem<TContext>;
     message?: string;
     chosenCardsMustHaveUniqueNames?: boolean;
     player?: Player;
     choosingPlayer?: Player;
-    messageArgs?: (context: AbilityContext, cards: Card[]) => any | any[];
+    messageArgs?: (context: TContext, cards: Card[]) => any | any[];
     /** Used to override default logic for handling the selected cards. The default utilizes the selectedCardsImmediateEffect */
-    selectedCardsHandler?: (context: AbilityContext, event: any, cards: Card[]) => void;
+    selectedCardsHandler?: (context: TContext, event: any, cards: Card[]) => void;
     /** Used to override default logic for handling the remaining cards. The default places them on the bottom of the deck. */
-    remainingCardsHandler?: (context: AbilityContext, event: any, cards: Card[]) => void;
+    remainingCardsHandler?: (context: TContext, event: any, cards: Card[]) => void;
     /** Used for filtering selection based on things like trait, type, etc. */
-    cardCondition?: (card: Card, context: AbilityContext) => boolean;
-    chooseNothingImmediateEffect?: GameSystem<IGameSystemProperties>;
+    cardCondition?: (card: Card, context: TContext) => boolean;
+    chooseNothingImmediateEffect?: GameSystem<TContext>;
 }
 
-export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> {
+export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext> extends PlayerTargetSystem<TContext, ISearchDeckProperties<TContext>> {
     public override readonly name = 'deckSearch';
     public override readonly eventName = EventName.OnDeckSearch;
 
@@ -60,8 +60,8 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public override eventHandler(event): void { }
 
-    public override hasLegalTarget(context: AbilityContext, additionalProperties = {}): boolean {
-        const properties = this.generatePropertiesFromContext(context, additionalProperties) as ISearchDeckProperties;
+    public override hasLegalTarget(context: TContext, additionalProperties = {}): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
         if (this.computeSearchCount(properties.searchCount, context) === 0) {
             return false;
         }
@@ -69,14 +69,14 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         return this.getDeck(player).length > 0 && super.canAffect(player, context);
     }
 
-    public override generatePropertiesFromContext(context: AbilityContext, additionalProperties = {}): ISearchDeckProperties {
-        const properties = super.generatePropertiesFromContext(context, additionalProperties) as ISearchDeckProperties;
+    public override generatePropertiesFromContext(context: TContext, additionalProperties = {}) {
+        const properties = super.generatePropertiesFromContext(context, additionalProperties);
 
         properties.cardCondition = properties.cardCondition || (() => true);
         return properties;
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
         const searchCountAmount = this.computeSearchCount(properties.searchCount, context);
         const message =
@@ -86,24 +86,24 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         return [message, []];
     }
 
-    public override canAffect(player: Player, context: AbilityContext, additionalProperties = {}): boolean {
-        const properties = this.generatePropertiesFromContext(context, additionalProperties) as ISearchDeckProperties;
+    public override canAffect(player: Player, context: TContext, additionalProperties = {}): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const searchCountAmount = this.computeSearchCount(properties.searchCount, context);
         return searchCountAmount !== 0 && this.getDeck(player).length > 0 && super.canAffect(player, context);
     }
 
-    public override defaultTargets(context: AbilityContext): Player[] {
+    public override defaultTargets(context: TContext): Player[] {
         return [context.player];
     }
 
-    protected override addPropertiesToEvent(event: any, player: Player, context: AbilityContext, additionalProperties: any): void {
-        const { searchCount } = this.generatePropertiesFromContext(context, additionalProperties) as ISearchDeckProperties;
+    protected override addPropertiesToEvent(event: any, player: Player, context: TContext, additionalProperties: any): void {
+        const { searchCount } = this.generatePropertiesFromContext(context, additionalProperties);
         const searchCountAmount = this.computeSearchCount(searchCount, context);
         super.addPropertiesToEvent(event, player, context, additionalProperties);
         event.amount = searchCountAmount;
     }
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const player = properties.player || context.player;
         const event = this.generateEvent(player, context, additionalProperties) as any;
@@ -117,15 +117,15 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         events.push(event);
     }
 
-    private getNumCards(numCards: Derivable<number>, context: AbilityContext): number {
+    private getNumCards(numCards: Derivable<number>, context: TContext): number {
         return typeof numCards === 'function' ? numCards(context) : numCards;
     }
 
-    private computeSearchCount(searchCount: Derivable<number>, context: AbilityContext): number {
+    private computeSearchCount(searchCount: Derivable<number>, context: TContext): number {
         return typeof searchCount === 'function' ? searchCount(context) : searchCount;
     }
 
-    private shouldShuffle(shuffle: Derivable<boolean>, context: AbilityContext): boolean {
+    private shouldShuffle(shuffle: Derivable<boolean>, context: TContext): boolean {
         return typeof shuffle === 'function' ? shuffle(context) : shuffle;
     }
 
@@ -134,7 +134,7 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
     }
 
     private selectCard(event: any, additionalProperties: any, cards: Card[], selectedCards: Set<Card>): void {
-        const context: AbilityContext = event.context;
+        const context: TContext = event.context;
         const properties = this.generatePropertiesFromContext(context, additionalProperties) as ISearchDeckProperties;
         const canCancel = properties.targetMode !== TargetMode.Exactly;
         let selectAmount = 1;
@@ -177,7 +177,7 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
             activePromptTitle: title,
             context: context,
             cards: cards,
-            cardCondition: (card: Card, context: AbilityContext) =>
+            cardCondition: (card: Card, context: TContext) =>
                 properties.cardCondition(card, context) &&
                 (!properties.chosenCardsMustHaveUniqueNames || !Array.from(selectedCards).some((sel) => sel.name === card.name)) &&
                 (!properties.selectedCardsImmediateEffect || properties.selectedCardsImmediateEffect.canAffect(card, context, additionalProperties)),
@@ -199,7 +199,7 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         });
     }
 
-    private onSearchComplete(properties: ISearchDeckProperties, context: AbilityContext, event: any, selectedCards: Set<Card>, allCards: Card[]): void {
+    private onSearchComplete(properties: ISearchDeckProperties, context: TContext, event: any, selectedCards: Set<Card>, allCards: Card[]): void {
         event.selectedCards = Array.from(selectedCards);
         context.selects['deckSearch'] = Array.from(selectedCards);
         this.searchCompleteHandler(properties, context, event, selectedCards);
@@ -219,7 +219,7 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         }
     }
 
-    private remainingCardsDefaultHandler(context: AbilityContext, event: any, cardsToMove: Card[]) {
+    private remainingCardsDefaultHandler(context: TContext, event: any, cardsToMove: Card[]) {
         if (cardsToMove.length > 0) {
             shuffleArray(cardsToMove);
             for (const card of cardsToMove) {
@@ -234,7 +234,7 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         }
     }
 
-    private selectedCardsDefaultHandler(properties: ISearchDeckProperties, context: AbilityContext, event: any, selectedCards: Set<Card>): void {
+    private selectedCardsDefaultHandler(properties: ISearchDeckProperties, context: TContext, event: any, selectedCards: Set<Card>): void {
         const gameSystem = this.generatePropertiesFromContext(event.context).selectedCardsImmediateEffect;
         if (gameSystem) {
             const selectedArray = Array.from(selectedCards);
@@ -248,7 +248,7 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         }
     }
 
-    private searchCompleteHandler(properties: ISearchDeckProperties, context: AbilityContext, event: any, selectedCards: Set<Card>): void {
+    private searchCompleteHandler(properties: ISearchDeckProperties, context: TContext, event: any, selectedCards: Set<Card>): void {
         const choosingPlayer = properties.choosingPlayer || event.player;
         if (selectedCards.size > 0 && properties.message) {
             const args = properties.messageArgs ? properties.messageArgs(context, Array.from(selectedCards)) : [];
@@ -271,7 +271,7 @@ export class SearchDeckSystem extends PlayerTargetSystem<ISearchDeckProperties> 
         );
     }
 
-    private chooseNothingHandler(properties: ISearchDeckProperties, context: AbilityContext, event: any) {
+    private chooseNothingHandler(properties: ISearchDeckProperties, context: TContext, event: any) {
         const choosingPlayer = properties.choosingPlayer || event.player;
         context.game.addMessage('{0} takes nothing', choosingPlayer);
         if (properties.chooseNothingImmediateEffect) {

--- a/server/game/gameSystems/SearchDeckSystem.ts
+++ b/server/game/gameSystems/SearchDeckSystem.ts
@@ -10,7 +10,7 @@ import { shuffleDeck } from './GameSystemLibrary.js';
 import { IPlayerTargetSystemProperties, PlayerTargetSystem } from '../core/gameSystem/PlayerTargetSystem.js';
 import Player from '../core/Player.js';
 import { shuffleArray } from '../core/utils/Helpers.js';
-import Contract from '../core/utils/Contract.js';
+import * as Contract from '../core/utils/Contract.js';
 
 type Derivable<T> = T | ((context: AbilityContext) => T);
 

--- a/server/game/gameSystems/SequentialSystem.ts
+++ b/server/game/gameSystems/SequentialSystem.ts
@@ -5,8 +5,8 @@ import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem
 import { MetaSystem } from '../core/gameSystem/MetaSystem';
 
 
-export interface ISequentialProperties extends IGameSystemProperties {
-    gameSystems: GameSystem[];
+export interface ISequentialProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
+    gameSystems: GameSystem<TContext>[];
 }
 
 // TODO: fix windows and trigger timing in general
@@ -18,15 +18,15 @@ export interface ISequentialProperties extends IGameSystemProperties {
  *
  * In terms of game text, this is the exact behavior of "do [X], then do [Y], then do..." or "do [X] [N] times"
  */
-export class SequentialSystem<TContext extends AbilityContext = AbilityContext> extends MetaSystem<TContext, ISequentialProperties> {
-    public constructor(gameSystems: (GameSystem | MetaSystem<TContext>)[]) {
+export class SequentialSystem<TContext extends AbilityContext = AbilityContext> extends MetaSystem<TContext, ISequentialProperties<TContext>> {
+    public constructor(gameSystems: (GameSystem<TContext>)[]) {
         super({ gameSystems });
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public override eventHandler() {}
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         for (const gameSystem of properties.gameSystems) {
             context.game.queueSimpleStep(() => {
@@ -47,25 +47,25 @@ export class SequentialSystem<TContext extends AbilityContext = AbilityContext> 
         }
     }
 
-    public override getEffectMessage(context: AbilityContext): [string, any] {
-        const properties = super.generatePropertiesFromContext(context) as ISequentialProperties;
+    public override getEffectMessage(context: TContext): [string, any] {
+        const properties = super.generatePropertiesFromContext(context);
         return properties.gameSystems[0].getEffectMessage(context);
     }
 
-    public override generatePropertiesFromContext(context: AbilityContext, additionalProperties = {}): ISequentialProperties {
-        const properties = super.generatePropertiesFromContext(context, additionalProperties) as ISequentialProperties;
+    public override generatePropertiesFromContext(context: TContext, additionalProperties = {}) {
+        const properties = super.generatePropertiesFromContext(context, additionalProperties);
         for (const gameSystem of properties.gameSystems) {
             gameSystem.setDefaultTargetFn(() => properties.target);
         }
         return properties;
     }
 
-    public override hasLegalTarget(context: AbilityContext, additionalProperties = {}): boolean {
+    public override hasLegalTarget(context: TContext, additionalProperties = {}): boolean {
         const { gameSystems } = this.generatePropertiesFromContext(context, additionalProperties);
         return gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context));
     }
 
-    public override canAffect(target: GameObject, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(target: GameObject, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.gameSystems.some((gameSystem) => gameSystem.canAffect(target, context));
     }

--- a/server/game/gameSystems/SequentialSystem.ts
+++ b/server/game/gameSystems/SequentialSystem.ts
@@ -2,6 +2,8 @@ import { AbilityContext } from '../core/ability/AbilityContext';
 import { GameEvent } from '../core/event/GameEvent';
 import { GameObject } from '../core/GameObject';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
+import { MetaSystem } from '../core/gameSystem/MetaSystem';
+
 
 export interface ISequentialProperties extends IGameSystemProperties {
     gameSystems: GameSystem[];
@@ -16,8 +18,8 @@ export interface ISequentialProperties extends IGameSystemProperties {
  *
  * In terms of game text, this is the exact behavior of "do [X], then do [Y], then do..." or "do [X] [N] times"
  */
-export class SequentialSystem extends GameSystem<ISequentialProperties> {
-    public constructor(gameSystems: GameSystem[]) {
+export class SequentialSystem<TContext extends AbilityContext = AbilityContext> extends MetaSystem<TContext, ISequentialProperties> {
+    public constructor(gameSystems: (GameSystem | MetaSystem<TContext>)[]) {
         super({ gameSystems });
     }
 

--- a/server/game/gameSystems/ShuffleDeckSystem.ts
+++ b/server/game/gameSystems/ShuffleDeckSystem.ts
@@ -5,11 +5,11 @@ import Player from '../core/Player';
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IShuffleDeckProperties extends IPlayerTargetSystemProperties {}
 
-export class ShuffleDeckSystem extends PlayerTargetSystem<IShuffleDeckProperties> {
+export class ShuffleDeckSystem<TContext extends AbilityContext = AbilityContext> extends PlayerTargetSystem<TContext, IShuffleDeckProperties> {
     public override readonly name = 'shuffle';
     public override readonly effectDescription = 'shuffle deck';
 
-    public override defaultTargets(context: AbilityContext): Player[] {
+    public override defaultTargets(context: TContext): Player[] {
         return [context.player];
     }
 

--- a/server/game/gameSystems/SimultaneousSystem.ts
+++ b/server/game/gameSystems/SimultaneousSystem.ts
@@ -3,8 +3,8 @@ import { GameObject } from '../core/GameObject';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
 import { MetaSystem } from '../core/gameSystem/MetaSystem';
 
-export interface ISimultaneousSystemProperties extends IGameSystemProperties {
-    gameSystems: GameSystem[];
+export interface ISimultaneousSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
+    gameSystems: GameSystem<TContext>[];
 
     /**
      * If this is set to true, we will assume every system has a legal target and trigger it.
@@ -13,20 +13,20 @@ export interface ISimultaneousSystemProperties extends IGameSystemProperties {
     ignoreTargetingRequirements?: boolean;
 }
 
-export class SimultaneousGameSystem<TContext extends AbilityContext = AbilityContext> extends MetaSystem<TContext, ISimultaneousSystemProperties> {
-    protected override readonly defaultProperties: ISimultaneousSystemProperties = {
+export class SimultaneousGameSystem<TContext extends AbilityContext = AbilityContext> extends MetaSystem<TContext, ISimultaneousSystemProperties<TContext>> {
+    protected override readonly defaultProperties: ISimultaneousSystemProperties<TContext> = {
         gameSystems: null,
         ignoreTargetingRequirements: false
     };
 
-    public constructor(gameSystems: (GameSystem | MetaSystem<TContext>)[], ignoreTargetingRequirements = null) {
+    public constructor(gameSystems: (GameSystem<TContext>)[], ignoreTargetingRequirements = null) {
         super({ gameSystems, ignoreTargetingRequirements });
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public override eventHandler() {}
 
-    public override getEffectMessage(context: AbilityContext): [string, any[]] {
+    public override getEffectMessage(context: TContext): [string, any[]] {
         const { gameSystems } = this.generatePropertiesFromContext(context);
         const legalSystems = gameSystems.filter((system) => system.hasLegalTarget(context));
         let message = '{0}';
@@ -37,7 +37,7 @@ export class SimultaneousGameSystem<TContext extends AbilityContext = AbilityCon
         return [message, legalSystems.map((system) => system.getEffectMessage(context))];
     }
 
-    public override generatePropertiesFromContext(context: AbilityContext, additionalProperties = {}): ISimultaneousSystemProperties {
+    public override generatePropertiesFromContext(context: TContext, additionalProperties = {}) {
         const properties = super.generatePropertiesFromContext(context, additionalProperties);
         for (const gameSystem of properties.gameSystems) {
             gameSystem.setDefaultTargetFn(() => properties.target);
@@ -45,39 +45,39 @@ export class SimultaneousGameSystem<TContext extends AbilityContext = AbilityCon
         return properties;
     }
 
-    public override hasLegalTarget(context: AbilityContext, additionalProperties = {}): boolean {
+    public override hasLegalTarget(context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
     }
 
-    public override canAffect(target: GameObject, context: AbilityContext, additionalProperties = {}): boolean {
+    public override canAffect(target: GameObject, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.gameSystems.some((gameSystem) => gameSystem.canAffect(target, context, additionalProperties));
     }
 
-    public override allTargetsLegal(context: AbilityContext, additionalProperties = {}): boolean {
+    public override allTargetsLegal(context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
     }
 
-    public override queueGenerateEventGameSteps(events: any[], context: AbilityContext, additionalProperties = {}): void {
+    public override queueGenerateEventGameSteps(events: any[], context: TContext, additionalProperties = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
-        let queueGenerateEventGameStepsFn: (gameSystem: GameSystem) => void;
-        let generateStepName: (gameSystem: GameSystem) => string;
+        let queueGenerateEventGameStepsFn: (gameSystem: GameSystem<TContext>) => void;
+        let generateStepName: (gameSystem: GameSystem<TContext>) => string;
 
         if (properties.ignoreTargetingRequirements) {
-            queueGenerateEventGameStepsFn = (gameSystem: GameSystem) => () => {
+            queueGenerateEventGameStepsFn = (gameSystem: GameSystem<TContext>) => () => {
                 gameSystem.queueGenerateEventGameSteps(events, context, additionalProperties);
             };
-            generateStepName = (gameSystem: GameSystem) => `queue generate event game steps for ${gameSystem.name}`;
+            generateStepName = (gameSystem: GameSystem<TContext>) => `queue generate event game steps for ${gameSystem.name}`;
         } else {
-            queueGenerateEventGameStepsFn = (gameSystem: GameSystem) => () => {
+            queueGenerateEventGameStepsFn = (gameSystem: GameSystem<TContext>) => () => {
                 if (gameSystem.hasLegalTarget(context, additionalProperties)) {
                     gameSystem.queueGenerateEventGameSteps(events, context, additionalProperties);
                 }
             };
-            generateStepName = (gameSystem: GameSystem) => `check targets and queue generate event game steps for ${gameSystem.name}`;
+            generateStepName = (gameSystem: GameSystem<TContext>) => `check targets and queue generate event game steps for ${gameSystem.name}`;
         }
 
         for (const gameSystem of properties.gameSystems) {

--- a/server/game/gameSystems/SimultaneousSystem.ts
+++ b/server/game/gameSystems/SimultaneousSystem.ts
@@ -1,6 +1,7 @@
 import { AbilityContext } from '../core/ability/AbilityContext';
 import { GameObject } from '../core/GameObject';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
+import { MetaSystem } from '../core/gameSystem/MetaSystem';
 
 export interface ISimultaneousSystemProperties extends IGameSystemProperties {
     gameSystems: GameSystem[];
@@ -12,13 +13,13 @@ export interface ISimultaneousSystemProperties extends IGameSystemProperties {
     ignoreTargetingRequirements?: boolean;
 }
 
-export class SimultaneousGameSystem extends GameSystem<ISimultaneousSystemProperties> {
+export class SimultaneousGameSystem<TContext extends AbilityContext = AbilityContext> extends MetaSystem<TContext, ISimultaneousSystemProperties> {
     protected override readonly defaultProperties: ISimultaneousSystemProperties = {
         gameSystems: null,
         ignoreTargetingRequirements: false
     };
 
-    public constructor(gameSystems: GameSystem[], ignoreTargetingRequirements = null) {
+    public constructor(gameSystems: (GameSystem | MetaSystem<TContext>)[], ignoreTargetingRequirements = null) {
         super({ gameSystems, ignoreTargetingRequirements });
     }
 

--- a/server/game/gameSystems/ViewCardSystem.ts
+++ b/server/game/gameSystems/ViewCardSystem.ts
@@ -3,6 +3,7 @@ import { BaseCard } from '../core/card/BaseCard';
 import { GameEvent } from '../core/event/GameEvent';
 import { CardTargetSystem, ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import Player from '../core/Player';
+import * as Helpers from '../core/utils/Helpers';
 
 //TODO: Need some future work to fully implement Thrawn
 export interface IViewCardProperties extends ICardTargetSystemProperties {
@@ -36,7 +37,7 @@ export abstract class ViewCardSystem extends CardTargetSystem<IViewCardPropertie
 
     public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
         const { target } = this.generatePropertiesFromContext(context, additionalProperties);
-        const cards = (target as BaseCard[]).filter((card) => this.canAffect(card, context));
+        const cards = Helpers.asArray(target).filter((card) => this.canAffect(card, context));
         if (cards.length === 0) {
             return;
         }

--- a/server/game/gameSystems/ViewCardSystem.ts
+++ b/server/game/gameSystems/ViewCardSystem.ts
@@ -25,7 +25,7 @@ export enum ViewCardMode {
     Reveal = 'reveal'
 }
 
-export abstract class ViewCardSystem extends CardTargetSystem<IViewCardProperties> {
+export abstract class ViewCardSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IViewCardProperties> {
     public override eventHandler(event, additionalProperties = {}): void {
         const context = event.context;
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
@@ -35,7 +35,7 @@ export abstract class ViewCardSystem extends CardTargetSystem<IViewCardPropertie
         }
     }
 
-    public override queueGenerateEventGameSteps(events: GameEvent[], context: AbilityContext, additionalProperties = {}): void {
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
         const { target } = this.generatePropertiesFromContext(context, additionalProperties);
         const cards = Helpers.asArray(target).filter((card) => this.canAffect(card, context));
         if (cards.length === 0) {
@@ -46,7 +46,7 @@ export abstract class ViewCardSystem extends CardTargetSystem<IViewCardPropertie
         events.push(event);
     }
 
-    public override addPropertiesToEvent(event, cards, context: AbilityContext, additionalProperties): void {
+    public override addPropertiesToEvent(event, cards, context: TContext, additionalProperties): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
         if (!cards) {
@@ -59,12 +59,12 @@ export abstract class ViewCardSystem extends CardTargetSystem<IViewCardPropertie
         event.context = context;
     }
 
-    public getMessage(message, context: AbilityContext): string {
+    public getMessage(message, context: TContext): string {
         if (typeof message === 'function') {
             return message(context);
         }
         return message;
     }
 
-    public abstract getMessageArgs(event: any, context: AbilityContext, additionalProperties);
+    public abstract getMessageArgs(event: any, context: TContext, additionalProperties);
 }

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -565,8 +565,6 @@ beforeEach(function () {
 global.integration = function (definitions) {
     describe('- integration -', function () {
         beforeEach(function () {
-            Contract.configureAssertMode(Contract.AssertMode.Assert, true);
-
             this.flow = new GameFlowWrapper();
 
             this.game = this.flow.game;


### PR DESCRIPTION
Major refactor to add much better support for type inference in common scenarios, as well as an improvement to error handling.

**Error handling and type assertions**
We decided that it is okay for `Contract` methods to throw an error even in prod, so we are able to refactor to use those as one-liners instead of needing to have extra logic that checks the result and returns something. In addition, we can now use assertion annotations for type narrowing. The end result is that what used to look like this

```typescript
  public override executeHandler(context: PlayCardContext): void {
      if (!Contract.assertTrue(context.source.isEvent())) {
          return;
      }

      context.game.addMessage(
          '{0} plays {1}',
          context.player,
          context.source,
      );
      context.game.resolveAbility((context.source as EventCard).getEventAbility().createContext());
  }
```

Now looks like this:

```typescript
  public override executeHandler(context: PlayCardContext): void {
      // after this check, context.source is inferred to be of type EventCard
      Contract.assertTrue(context.source.isEvent());

      context.game.addMessage(
          '{0} plays {1}',
          context.player,
          context.source,
      );

      // cast to EventCard no longer needed
      context.game.resolveAbility(context.source.getEventAbility().createContext());
  }
```

**Type inference for `context.source`**
A frequent frustration is that `context.source` appears as the `any` type or as a generic `Card`, which creates issues when trying to use properties that are only available in a subclass (e.g., damage only exists on `UnitCard`).

Added a generic parameter to GameSystem so that the AbilityContext it accepts can be specified. The end result is that `context.source` will always be of type `this`, so that the properties and methods of the current card can be accessed without a cast. See the Shield ability as an example:

```typescript
// shield ability before
this.addReplacementEffectAbility({
    title: 'Defeat shield to prevent attached unit from taking damage',
    when: {
        onDamageDealt: (event, context) => event.card === (context.source as UpgradeCard).parentCard
    },
    replaceWith: {
        target: this,
        replacementImmediateEffect: AbilityHelper.immediateEffects.defeat()
    },
    effect: 'shield prevents {1} from taking damage',
    effectArgs: (context) => [(context.source as UpgradeCard).parentCard],
});
```

```typescript
// shield ability after - no casts needed
this.addReplacementEffectAbility({
    title: 'Defeat shield to prevent attached unit from taking damage',
    when: {
        onDamageDealt: (event, context) => event.card === context.source.parentCard
    },
    replaceWith: {
        target: this,
        replacementImmediateEffect: AbilityHelper.immediateEffects.defeat()
    },
    effect: 'shield prevents {1} from taking damage',
    effectArgs: (context) => [context.source.parentCard],
});
```

Also the Vambrace Grappleshot ability, which can directly reference the `activeAttack` property now:

```typescript
  this.addGainTriggeredAbilityTargetingAttached({
      title: 'Exhaust the defender on attack',
      when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
      immediateEffect: AbilityHelper.immediateEffects.exhaust((context) => {
          return { target: context.source.activeAttack?.target };    // no cast needed
      })
  });
```

Also, because `context.source` now has type data, there will be auto-complete for its properties.