### PR TITLE
Re-enable parallel test run

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -34,5 +34,4 @@ jobs:
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards
 
-        # TODO: figure out why test-parallel gives weird error on test failure
         - run: npm run test-parallel

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -35,4 +35,4 @@ jobs:
           run: npm run get-cards
 
         # TODO: figure out why test-parallel gives weird error on test failure
-        - run: npm test
+        - run: npm run test-parallel

--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ npm run lint-verbose
 
 # runs tsc and executes tests
 npm test
+# run all tests in parallel for higher speed
+npm run test-parallel
 
 # run a specific test file only
 npm test test/server/cards/01_SOR/LukeSkywalkerFaithfulFriend.spec.js
 npm test **/LukeSkywalkerFaithfulFriend.spec.js # use path globbing (may look different depending on your shell)
-
-# this currently has a bug, do not use
-#npm run test-parallel   # runs tests in parallel for higher speed
 ```
 
 ### Linting


### PR DESCRIPTION
The parallel test setting was having issue in the past so we disabled it in github actions and recommended people not use it. It currently seems that the problem is gone, so re-enabling everything for now and will monitor to see if any issues occur.