### PR TITLE
Improve some card properties and fix ActiveAttack issue

### DIFF
--- a/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
+++ b/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
@@ -2,11 +2,13 @@ import AbilityHelper from '../../AbilityHelper';
 import Shield from '../../cards/01_SOR/tokens/Shield';
 import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import { TriggeredAbilityContext } from '../../core/ability/TriggeredAbilityContext';
+import { Attack } from '../../core/attack/Attack';
 import { Card } from '../../core/card/Card';
 import { UnitCard } from '../../core/card/CardTypes';
 import { KeywordName } from '../../core/Constants';
 import Game from '../../core/Game';
 import * as Contract from '../../core/utils/Contract';
+import * as EnumHelpers from '../../core/utils/EnumHelpers';
 import { ITriggeredAbilityProps } from '../../Interfaces';
 
 export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
@@ -23,14 +25,15 @@ export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
                         return false;
                     }
 
-                    return card === attacker.activeAttack.target && card.hasShield();
+                    return card === context.event.attack.target && card.hasShield();
                 },
                 immediateEffect: AbilityHelper.immediateEffects.defeat((context) => {
                     Contract.assertTrue(context.source.isUnit());
 
                     let target: Shield[];
-                    if (context.source.activeAttack?.target.isUnit()) {
-                        target = context.source.activeAttack.target.upgrades?.filter((card) => card.isShield());
+                    const attack: Attack = context.event.attack;
+                    if (attack.target.isUnit() && EnumHelpers.isArena(attack.target.location)) {
+                        target = attack.target.upgrades?.filter((card) => card.isShield());
                     } else {
                         target = [];
                     }

--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -11,10 +11,6 @@ type StatisticTotal = number;
 export class Attack extends GameObject {
     public previousAttack: Attack;
 
-    public get participants(): undefined | Card[] {
-        return [...[this.attacker], this.target];
-    }
-
     public get attackerTotalPower(): number | null {
         return this.getUnitPower(this.attacker);
     }

--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -53,6 +53,6 @@ export class Attack extends GameObject {
     private getUnitPower(involvedUnit: UnitCard): StatisticTotal {
         Contract.assertTrue(EnumHelpers.isArena(involvedUnit.location), `Unit ${involvedUnit.name} location is ${involvedUnit.location}, cannot participate in combat`);
 
-        return involvedUnit.power;
+        return involvedUnit.getPower();
     }
 }

--- a/server/game/core/card/BaseCard.ts
+++ b/server/game/core/card/BaseCard.ts
@@ -22,8 +22,8 @@ export class BaseCard extends BaseCardParent {
         super(owner, cardData);
         Contract.assertEqual(this.printedType, CardType.Base);
 
-        this.enableDamage(true);
-        this.enableActiveAttack(true);
+        this.setDamageEnabled(true);
+        this.setActiveAttackEnabled(true);
     }
 
     public override isBase(): this is BaseCard {

--- a/server/game/core/card/BaseCard.ts
+++ b/server/game/core/card/BaseCard.ts
@@ -23,6 +23,7 @@ export class BaseCard extends BaseCardParent {
         Contract.assertEqual(this.printedType, CardType.Base);
 
         this.enableDamage(true);
+        this.enableActiveAttack(true);
     }
 
     public override isBase(): this is BaseCard {

--- a/server/game/core/card/EventCard.ts
+++ b/server/game/core/card/EventCard.ts
@@ -38,11 +38,11 @@ export class EventCard extends EventCardParent {
         // event cards can only be exhausted when resourced
         switch (this.location) {
             case Location.Resource:
-                this.enableExhaust(true);
+                this.setExhaustEnabled(true);
                 break;
 
             default:
-                this.enableExhaust(false);
+                this.setExhaustEnabled(false);
                 break;
         }
     }

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -105,12 +105,14 @@ export class LeaderUnitCard extends LeaderUnitCardParent {
             case Location.SpaceArena:
                 this._deployed = true;
                 this.enableDamage(true);
+                this.enableActiveAttack(true);
                 this.exhausted = false;
                 break;
 
             case Location.Base:
                 this._deployed = false;
                 this.enableDamage(false);
+                this.enableActiveAttack(false);
                 this.exhausted = EnumHelpers.isArena(prevLocation);
                 break;
         }

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -106,6 +106,7 @@ export class LeaderUnitCard extends LeaderUnitCardParent {
                 this._deployed = true;
                 this.enableDamage(true);
                 this.enableActiveAttack(true);
+                this.enableUpgrades(true);
                 this.exhausted = false;
                 break;
 
@@ -113,6 +114,7 @@ export class LeaderUnitCard extends LeaderUnitCardParent {
                 this._deployed = false;
                 this.enableDamage(false);
                 this.enableActiveAttack(false);
+                this.enableUpgrades(false);
                 this.exhausted = EnumHelpers.isArena(prevLocation);
                 break;
         }

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -25,7 +25,7 @@ export class LeaderUnitCard extends LeaderUnitCardParent {
         this.setupLeaderUnitSideAbilities();
 
         // leaders are always in a zone where they are allowed to be exhausted
-        this.enableExhaust(true);
+        this.setExhaustEnabled(true);
 
         // add deploy leader action
         this.addActionAbility({
@@ -104,17 +104,17 @@ export class LeaderUnitCard extends LeaderUnitCardParent {
             case Location.GroundArena:
             case Location.SpaceArena:
                 this._deployed = true;
-                this.enableDamage(true);
-                this.enableActiveAttack(true);
-                this.enableUpgrades(true);
+                this.setDamageEnabled(true);
+                this.setActiveAttackEnabled(true);
+                this.setUpgradesEnabled(true);
                 this.exhausted = false;
                 break;
 
             case Location.Base:
                 this._deployed = false;
-                this.enableDamage(false);
-                this.enableActiveAttack(false);
-                this.enableUpgrades(false);
+                this.setDamageEnabled(false);
+                this.setActiveAttackEnabled(false);
+                this.setUpgradesEnabled(false);
                 this.exhausted = EnumHelpers.isArena(prevLocation);
                 break;
         }

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -37,18 +37,21 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent {
                 this.enableActiveAttack(true);
                 this.enableDamage(true);
                 this.enableExhaust(true);
+                this.enableUpgrades(true);
                 break;
 
             case Location.Resource:
                 this.enableActiveAttack(false);
                 this.enableDamage(false);
                 this.enableExhaust(true);
+                this.enableUpgrades(false);
                 break;
 
             default:
                 this.enableActiveAttack(false);
                 this.enableDamage(false);
                 this.enableExhaust(false);
+                this.enableUpgrades(false);
                 break;
         }
     }

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -34,16 +34,19 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent {
         switch (this.location) {
             case Location.GroundArena:
             case Location.SpaceArena:
+                this.enableActiveAttack(true);
                 this.enableDamage(true);
                 this.enableExhaust(true);
                 break;
 
             case Location.Resource:
+                this.enableActiveAttack(false);
                 this.enableDamage(false);
                 this.enableExhaust(true);
                 break;
 
             default:
+                this.enableActiveAttack(false);
                 this.enableDamage(false);
                 this.enableExhaust(false);
                 break;

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -34,24 +34,24 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent {
         switch (this.location) {
             case Location.GroundArena:
             case Location.SpaceArena:
-                this.enableActiveAttack(true);
-                this.enableDamage(true);
-                this.enableExhaust(true);
-                this.enableUpgrades(true);
+                this.setActiveAttackEnabled(true);
+                this.setDamageEnabled(true);
+                this.setExhaustEnabled(true);
+                this.setUpgradesEnabled(true);
                 break;
 
             case Location.Resource:
-                this.enableActiveAttack(false);
-                this.enableDamage(false);
-                this.enableExhaust(true);
-                this.enableUpgrades(false);
+                this.setActiveAttackEnabled(false);
+                this.setDamageEnabled(false);
+                this.setExhaustEnabled(true);
+                this.setUpgradesEnabled(false);
                 break;
 
             default:
-                this.enableActiveAttack(false);
-                this.enableDamage(false);
-                this.enableExhaust(false);
-                this.enableUpgrades(false);
+                this.setActiveAttackEnabled(false);
+                this.setDamageEnabled(false);
+                this.setExhaustEnabled(false);
+                this.setUpgradesEnabled(false);
                 break;
         }
     }

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -133,11 +133,11 @@ export class UpgradeCard extends UpgradeCardParent {
 
         switch (this.location) {
             case Location.Resource:
-                this.enableExhaust(true);
+                this.setExhaustEnabled(true);
                 break;
 
             default:
-                this.enableExhaust(false);
+                this.setExhaustEnabled(false);
                 break;
         }
     }

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -60,7 +60,7 @@ export class PlayableOrDeployableCard extends Card {
     }
 
 
-    protected enableExhaust(enabledStatus: boolean) {
+    protected setExhaustEnabled(enabledStatus: boolean) {
         this._exhausted = enabledStatus ? true : null;
     }
 }

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -64,7 +64,7 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
             this.damage += amount;
 
             // TODO EFFECTS: the win and defeat effects should almost certainly be handled elsewhere, probably in a game state check
-            if (this.damage >= this.hp) {
+            if (this.damage >= this.getHp()) {
                 if (this.isBase()) {
                     this.game.recordWinner(this.owner.opponent, 'base destroyed');
                 } else {

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -13,18 +13,28 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
 
     return class WithDamage extends HpClass {
         private _activeAttack?: Attack = null;
+        private attackEnabled = false;
         private _damage?: number;
 
         public setActiveAttack(attack: Attack) {
-            // this.assertPropertyEnabled(this._activeAttack, 'activeAttack');
+            Contract.assertNotNullLike(attack);
+            this.assertPropertyEnabledBoolean(this.attackEnabled, 'activeAttack');
             this._activeAttack = attack;
         }
 
+        public unsetActiveAttack() {
+            this.assertPropertyEnabledBoolean(this.attackEnabled, 'activeAttack');
+            if (this._activeAttack !== null) {
+                this._activeAttack = null;
+            }
+        }
+
         public isDefending(): boolean {
-            return (this as Card) === (this._activeAttack?.target as Card);
+            return (this as Card) === (this.activeAttack?.target as Card);
         }
 
         public get activeAttack() {
+            this.assertPropertyEnabledBoolean(this.attackEnabled, 'activeAttack');
             return this._activeAttack;
         }
 
@@ -78,6 +88,18 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
 
         protected enableDamage(enabledStatus: boolean) {
             this._damage = enabledStatus ? 0 : null;
+        }
+
+        protected enableActiveAttack(enabledStatus: boolean) {
+            if (!enabledStatus) {
+                if (this._activeAttack !== null) {
+                    this.unsetActiveAttack();
+                }
+            } else {
+                Contract.assertTrue(this._activeAttack === null, `Moved ${this.internalName} to ${this.location} but it has an active attack set`);
+            }
+
+            this.attackEnabled = enabledStatus;
         }
     };
 }

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -48,6 +48,11 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
             this._damage = value;
         }
 
+        public get remainingHp(): number {
+            this.assertPropertyEnabled(this._damage, 'damage');
+            return Math.max(0, this.getHp() - this.damage);
+        }
+
         public override canBeDamaged(): this is CardWithDamageProperty {
             return true;
         }

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -86,11 +86,11 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
             return true;
         }
 
-        protected enableDamage(enabledStatus: boolean) {
+        protected setDamageEnabled(enabledStatus: boolean) {
             this._damage = enabledStatus ? 0 : null;
         }
 
-        protected enableActiveAttack(enabledStatus: boolean) {
+        protected setActiveAttackEnabled(enabledStatus: boolean) {
             if (!enabledStatus) {
                 if (this._activeAttack !== null) {
                     this.unsetActiveAttack();

--- a/server/game/core/card/propertyMixins/PrintedHp.ts
+++ b/server/game/core/card/propertyMixins/PrintedHp.ts
@@ -10,10 +10,6 @@ export function WithPrintedHp<TBaseClass extends CardConstructor>(BaseClass: TBa
     return class WithPrintedHp extends BaseClass {
         public readonly printedHp: number;
 
-        public get hp(): number {
-            return this.printedHp;
-        }
-
         // see Card constructor for list of expected args
         public constructor(...args: any[]) {
             super(...args);
@@ -21,6 +17,10 @@ export function WithPrintedHp<TBaseClass extends CardConstructor>(BaseClass: TBa
 
             Contract.assertNotNullLike(cardData.hp);
             this.printedHp = cardData.hp;
+        }
+
+        public getHp(): number {
+            return this.printedHp;
         }
     };
 }

--- a/server/game/core/card/propertyMixins/PrintedPower.ts
+++ b/server/game/core/card/propertyMixins/PrintedPower.ts
@@ -6,10 +6,6 @@ export function WithPrintedPower<TBaseClass extends CardConstructor>(BaseClass: 
     return class WithPrintedPower extends BaseClass {
         public readonly printedPower: number;
 
-        public get power(): number {
-            return this.printedPower;
-        }
-
         // see Card constructor for list of expected args
         public constructor(...args: any[]) {
             super(...args);
@@ -17,6 +13,10 @@ export function WithPrintedPower<TBaseClass extends CardConstructor>(BaseClass: 
 
             Contract.assertNotNullLike(cardData.power);
             this.printedPower = cardData.power;
+        }
+
+        public getPower(): number {
+            return this.printedPower;
         }
     };
 }

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -41,14 +41,6 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         private _attackKeywordAbilities?: (TriggeredAbility | IConstantAbility)[] = null;
         private _whenPlayedKeywordAbilities?: (TriggeredAbility | IConstantAbility)[] = null;
 
-        public override get hp(): number {
-            return this.getModifiedStatValue(StatType.Hp);
-        }
-
-        public override get power(): number {
-            return this.getModifiedStatValue(StatType.Power);
-        }
-
         public get upgrades(): UpgradeCard[] {
             this.assertPropertyEnabled(this._upgrades, 'upgrades');
             return this._upgrades;
@@ -83,6 +75,15 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             }
 
             this.defaultActions.push(new InitiateAttackAction(this));
+        }
+
+        // ****************************************** PROPERTY HELPERS ******************************************
+        public override getHp(): number {
+            return this.getModifiedStatValue(StatType.Hp);
+        }
+
+        public override getPower(): number {
+            return this.getModifiedStatValue(StatType.Power);
         }
 
         public override isUnit(): this is UnitCard {

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -136,6 +136,12 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         }
 
         // *************************************** KEYWORD HELPERS ***************************************
+        protected override cleanupBeforeMove(nextLocation: Location) {
+            if (EnumHelpers.isArena(this.location) && this.isAttacking()) {
+                this.unregisterAttackKeywords();
+            }
+        }
+
         /**
          * For the "numeric" keywords (e.g. Raid), finds all instances of that keyword that are active
          * for this card and adds up the total of their effect values.

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -352,7 +352,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             super.leavesPlay();
         }
 
-        protected enableUpgrades(enabledStatus: boolean) {
+        protected setUpgradesEnabled(enabledStatus: boolean) {
             this._upgrades = enabledStatus ? [] : null;
         }
     };

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -37,9 +37,9 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         // ************************************* FIELDS AND PROPERTIES *************************************
         public readonly defaultArena: Arena;
 
-        protected _upgrades: UpgradeCard[] = [];
-        private _attackKeywordAbilities: (TriggeredAbility | IConstantAbility)[] | null = null;
-        private _whenPlayedKeywordAbilities: (TriggeredAbility | IConstantAbility)[] | null = null;
+        protected _upgrades?: UpgradeCard[] = null;
+        private _attackKeywordAbilities?: (TriggeredAbility | IConstantAbility)[] = null;
+        private _whenPlayedKeywordAbilities?: (TriggeredAbility | IConstantAbility)[] = null;
 
         public override get hp(): number {
             return this.getModifiedStatValue(StatType.Hp);
@@ -50,6 +50,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         }
 
         public get upgrades(): UpgradeCard[] {
+            this.assertPropertyEnabled(this._upgrades, 'upgrades');
             return this._upgrades;
         }
 
@@ -58,7 +59,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         }
 
         public hasShield(): boolean {
-            return this._upgrades.some((card) => card.isShield());
+            return this.upgrades.some((card) => card.isShield());
         }
 
         // ****************************************** CONSTRUCTOR ******************************************
@@ -316,13 +317,15 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
          * @param {UpgradeCard} upgrade
          */
         public unattachUpgrade(upgrade) {
-            this._upgrades = this.upgrades.filter((card) => card.uuid !== upgrade.uuid);
+            this.assertPropertyEnabled(this._upgrades, 'upgrades');
+            this._upgrades = this._upgrades.filter((card) => card.uuid !== upgrade.uuid);
         }
 
         /**
          * Add the passed card to this card's upgrade list. Upgrade must already be moved to the correct arena.
          */
         public attachUpgrade(upgrade) {
+            this.assertPropertyEnabled(this._upgrades, 'upgrades');
             Contract.assertEqual(upgrade.location, this.location);
             Contract.assertTrue(this.controller.getCardPile(this.location).includes(upgrade));
 
@@ -347,6 +350,10 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             // }
 
             super.leavesPlay();
+        }
+
+        protected enableUpgrades(enabledStatus: boolean) {
+            this._upgrades = enabledStatus ? [] : null;
         }
     };
 }

--- a/test/server/actions/PlayUpgradeFromHand.spec.js
+++ b/test/server/actions/PlayUpgradeFromHand.spec.js
@@ -23,8 +23,8 @@ describe('Play upgrade from hand', function() {
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.upgrades).toContain(this.entrenched);
                 expect(this.entrenched).toBeInLocation('ground arena');
-                expect(this.wampa.power).toBe(7);
-                expect(this.wampa.hp).toBe(8);
+                expect(this.wampa.getPower()).toBe(7);
+                expect(this.wampa.getHp()).toBe(8);
 
                 expect(this.player1.countExhaustedResources()).toBe(2);
 
@@ -36,8 +36,8 @@ describe('Play upgrade from hand', function() {
                 this.player1.clickCard(this.tielnFighter);
                 expect(this.tielnFighter.upgrades).toContain(this.academyTraining);
                 expect(this.academyTraining).toBeInLocation('space arena');
-                expect(this.tielnFighter.power).toBe(4);
-                expect(this.tielnFighter.hp).toBe(3);
+                expect(this.tielnFighter.getPower()).toBe(4);
+                expect(this.tielnFighter.getHp()).toBe(3);
 
                 expect(this.player1.countExhaustedResources()).toBe(6);
 
@@ -49,8 +49,8 @@ describe('Play upgrade from hand', function() {
                 this.player1.clickCard(this.brightHope);
                 expect(this.brightHope.upgrades).toContain(this.resilient);
                 expect(this.resilient).toBeInLocation('space arena', this.player2);
-                expect(this.brightHope.power).toBe(2);
-                expect(this.brightHope.hp).toBe(9);
+                expect(this.brightHope.getPower()).toBe(2);
+                expect(this.brightHope.getHp()).toBe(9);
 
                 // confirm that the upgrade is still controlled by the player who played it
                 expect(this.resilient.controller).toBe(this.player1.player);
@@ -80,8 +80,8 @@ describe('Play upgrade from hand', function() {
 
                 expect(this.wampa.upgrades).toContain(this.academyTraining);
                 expect(this.wampa.upgrades).toContain(this.foundling);
-                expect(this.wampa.power).toBe(7);
-                expect(this.wampa.hp).toBe(8);
+                expect(this.wampa.getPower()).toBe(7);
+                expect(this.wampa.getHp()).toBe(8);
             });
 
             it('its stat bonuses should be correctly applied during combat', function () {

--- a/test/server/cards/01_SOR/events/Disarm.spec.js
+++ b/test/server/cards/01_SOR/events/Disarm.spec.js
@@ -23,11 +23,11 @@ describe('Disarm', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.atst, this.isbAgent, this.tielnFighter, this.cartelSpacer]);
 
                 this.player1.clickCard(this.atst);
-                expect(this.atst.power).toBe(2);
+                expect(this.atst.getPower()).toBe(2);
 
                 // move to next phase and confirm effect is ended
                 this.moveToNextActionPhase();
-                expect(this.atst.power).toBe(6);
+                expect(this.atst.getPower()).toBe(6);
             });
 
             // TODO SNOKE: maybe migrate these to their own test suite once we do the full stat effects PR
@@ -36,7 +36,7 @@ describe('Disarm', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.atst, this.isbAgent, this.tielnFighter, this.cartelSpacer]);
 
                 this.player1.clickCard(this.isbAgent);
-                expect(this.isbAgent.power).toBe(0);
+                expect(this.isbAgent.getPower()).toBe(0);
             });
 
             it('should reduce a unit\'s power to 0 accounting for additive effects', function () {
@@ -44,7 +44,7 @@ describe('Disarm', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.atst, this.isbAgent, this.tielnFighter, this.cartelSpacer]);
 
                 this.player1.clickCard(this.tielnFighter);
-                expect(this.tielnFighter.power).toBe(0);
+                expect(this.tielnFighter.getPower()).toBe(0);
             });
 
             it('should reduce a unit\'s power to above 0 if additive effects are big enough', function () {
@@ -52,7 +52,7 @@ describe('Disarm', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.atst, this.isbAgent, this.tielnFighter, this.cartelSpacer]);
 
                 this.player1.clickCard(this.cartelSpacer);
-                expect(this.cartelSpacer.power).toBe(1);
+                expect(this.cartelSpacer.getPower()).toBe(1);
             });
         });
     });

--- a/test/server/cards/01_SOR/leaders/DirectorKrennicAspiringToAuthority.spec.js
+++ b/test/server/cards/01_SOR/leaders/DirectorKrennicAspiringToAuthority.spec.js
@@ -16,17 +16,17 @@ describe('Director Krennic, Aspiring to Authority', function() {
             });
 
             it('should give friendly damaged units +1/+0', function () {
-                expect(this.wampa.power).toBe(5);
-                expect(this.wampa.hp).toBe(5);
+                expect(this.wampa.getPower()).toBe(5);
+                expect(this.wampa.getHp()).toBe(5);
 
-                expect(this.battlefieldMarine.power).toBe(3);
-                expect(this.battlefieldMarine.hp).toBe(3);
+                expect(this.battlefieldMarine.getPower()).toBe(3);
+                expect(this.battlefieldMarine.getHp()).toBe(3);
 
-                expect(this.cartelSpacer.power).toBe(3);
-                expect(this.cartelSpacer.hp).toBe(3);
+                expect(this.cartelSpacer.getPower()).toBe(3);
+                expect(this.cartelSpacer.getHp()).toBe(3);
 
-                expect(this.consularSecurityForce.power).toBe(3);
-                expect(this.consularSecurityForce.hp).toBe(7);
+                expect(this.consularSecurityForce.getPower()).toBe(3);
+                expect(this.consularSecurityForce.getHp()).toBe(7);
 
                 // do an attack to ensure the ability is being applied correctly in combat
                 this.player1.clickCard(this.wampa);
@@ -53,20 +53,20 @@ describe('Director Krennic, Aspiring to Authority', function() {
             });
 
             it('should give friendly damaged units +1/+0', function () {
-                expect(this.directorKrennic.power).toBe(3);
-                expect(this.directorKrennic.hp).toBe(7);
+                expect(this.directorKrennic.getPower()).toBe(3);
+                expect(this.directorKrennic.getHp()).toBe(7);
 
-                expect(this.wampa.power).toBe(5);
-                expect(this.wampa.hp).toBe(5);
+                expect(this.wampa.getPower()).toBe(5);
+                expect(this.wampa.getHp()).toBe(5);
 
-                expect(this.battlefieldMarine.power).toBe(3);
-                expect(this.battlefieldMarine.hp).toBe(3);
+                expect(this.battlefieldMarine.getPower()).toBe(3);
+                expect(this.battlefieldMarine.getHp()).toBe(3);
 
-                expect(this.cartelSpacer.power).toBe(3);
-                expect(this.cartelSpacer.hp).toBe(3);
+                expect(this.cartelSpacer.getPower()).toBe(3);
+                expect(this.cartelSpacer.getHp()).toBe(3);
 
-                expect(this.consularSecurityForce.power).toBe(3);
-                expect(this.consularSecurityForce.hp).toBe(7);
+                expect(this.consularSecurityForce.getPower()).toBe(3);
+                expect(this.consularSecurityForce.getHp()).toBe(7);
 
                 // do an attack to ensure the ability is being applied correctly in combat
                 this.player1.clickCard(this.wampa);

--- a/test/server/cards/01_SOR/units/JedhaAgitator.spec.js
+++ b/test/server/cards/01_SOR/units/JedhaAgitator.spec.js
@@ -80,5 +80,33 @@ describe('Jedha Agitator', function() {
                 expect(this.p2Base.damage).toBe(4);     // attack did not resolve
             });
         });
+
+        describe('Jedha Agitator\'s on attack ability', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['jedha-agitator', 'battlefield-marine'],
+                        spaceArena: ['tieln-fighter'],
+                        leader: { card: 'hunter#outcast-sergeant', deployed: true }
+                    },
+                    player2: {
+                        groundArena: [{ card: 'wampa', upgrades: ['shield'] }],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+            });
+
+            it('should not prevent the Saboteur shield defeat if used to defeat itself', function () {
+                this.player1.clickCard(this.jedhaAgitator);
+                this.player1.clickCard(this.wampa);
+                this.player1.clickPrompt('If you control a leader unit, deal 2 damage to a ground unit or base');
+                this.player1.clickCard(this.jedhaAgitator);
+
+                expect(this.jedhaAgitator).toBeInLocation('discard');
+                expect(this.wampa.upgrades.length).toBe(0);
+                expect(this.wampa.damage).toBe(0);
+            });
+        });
     });
 });

--- a/test/server/core/abilities/keyword/Grit.spec.js
+++ b/test/server/core/abilities/keyword/Grit.spec.js
@@ -14,7 +14,7 @@ describe('Grit keyword', function() {
             });
 
             it('is damaged, power should be increased by damage amount', function () {
-                expect(this.scoutBikePursuer.power).toBe(3);
+                expect(this.scoutBikePursuer.getPower()).toBe(3);
 
                 this.player2.setActivePlayer();
                 this.player2.clickCard(this.regionalGovernor);
@@ -25,7 +25,7 @@ describe('Grit keyword', function() {
 
             it('has no damage, it should not have increased power', function () {
                 this.scoutBikePursuer.damage = 0;
-                expect(this.scoutBikePursuer.power).toBe(1);
+                expect(this.scoutBikePursuer.getPower()).toBe(1);
             });
         });
 
@@ -49,7 +49,7 @@ describe('Grit keyword', function() {
                 this.player1.clickCard(this.wookieeWarrior);
                 expect(this.sabineWren).toBeInLocation('discard');
                 expect(this.wookieeWarrior.damage).toBe(3);
-                expect(this.wookieeWarrior.power).toBe(5);
+                expect(this.wookieeWarrior.getPower()).toBe(5);
             });
         });
     });

--- a/test/server/core/abilities/keyword/Raid.spec.js
+++ b/test/server/core/abilities/keyword/Raid.spec.js
@@ -17,7 +17,7 @@ describe('Raid keyword', function() {
                 this.player1.clickCard(this.cantinaBraggart);
                 this.player1.clickCard(this.p2Base);
                 expect(this.cantinaBraggart.exhausted).toBe(true);
-                expect(this.cantinaBraggart.power).toBe(0);
+                expect(this.cantinaBraggart.getPower()).toBe(0);
                 expect(this.p2Base.damage).toBe(2);
 
                 this.cantinaBraggart.exhausted = false;
@@ -25,7 +25,7 @@ describe('Raid keyword', function() {
 
                 this.player1.clickCard(this.cantinaBraggart);
                 this.player1.clickCard(this.p2Base);
-                expect(this.cantinaBraggart.power).toBe(0);
+                expect(this.cantinaBraggart.getPower()).toBe(0);
                 expect(this.p2Base.damage).toBe(4);
             });
 


### PR DESCRIPTION
Improved some of the common card properties to make them safer / easier to use:

- Added a `remainingHp` property that returns `max(0, hp - damage)`
- Renamed the `hp` and `power` properties to `getHp()` and `getPower()` to make it clearer that they involve some complex checking logic
- Added a guard on the `.upgrades` property so that it can't be used when the card is not in an arena (same as for damage)
- Added a similar guard on the `.activeAttack` property

As a result of the last change above, found an issue where units that were defeated in combat would still have an "active" attack after moving to discard. This does not currently cause any problems but is not in line with the rules as the unit is no longer involved in an attack once defeated. It could also cause confusion in the future. Therefore, added additional logic to clean up the property immediately when the unit leaves the play area for any reason.