### PR TITLE
Remove unnecessary defeat check from damage method

### DIFF
--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -265,7 +265,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         public override addDamage(amount: number) {
             super.addDamage(amount);
 
-            this.checkDefeated();
+            // the defeat check will happen in the next call to Game.resolveGameState (typically when the event window resolves)
         }
 
         public checkDefeated() {


### PR DESCRIPTION
With the change to the defeat system, checking for defeat at damage time is now redundant since the check will happen at the next call to resolveGameState.